### PR TITLE
Only run cibuildwheel on pre-release versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
         - PYTHON="python"
         - PIP="pip"
 
-
 env:
   global:
     # Twine username
@@ -67,19 +66,20 @@ install:
 
 
 script:
-  # Use our patched version of cibuildwheel
-  - $PIP install cibuildwheel==1.0.0
-
-  # Run cibuildwheel
-  - cibuildwheel --output-dir wheelhouse
-
-  # List the results
-  - ls wheelhouse
+  script: 
+    # Install cibuildwheel
+    - $PIP install cibuildwheel==1.0.0
+    # Run cibuildwheel
+    - cibuildwheel --output-dir wheelhouse
+    # List the results
+    - ls wheelhouse
+  on:
+    # Only run on pre-release versions
+    if: (tag =~ /^v\d\.\d\.\d.*/) and (branch = master)
 
 deploy:
   skip_cleanup: true
   provider: script
   script: ls -1 wheelhouse && $PIP install twine && $PYTHON -m twine upload --verbose --skip-existing wheelhouse/*
   on:
-    branch: master
-    tag: true
+    if: (tag =~ /^v\d\.\d\.\d*/) and (branch = master)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         - PIP="pip3"
 
     - os: osx
-      language: generic
+      language: shell
       env:
         - CC="gcc"
         - PYTHON="python3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,8 @@ install:
 script:
   - if [[ "${TRAVIS_TAG:-}" =~ ^v[0-9]\.[0-9]\.[0-9].*$ ]]; then
       $PIP install cibuildwheel==1.0.0 && cibuildwheel --output-dir wheelhouse && ls -1 wheelhouse;
+    else
+      echo "No valid git tag present so not running cibuildwheel.";
     fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 # The matrix defines the platform on which we build the wheels and run the 
 # unit tests. Since we use manylinux for the linux wheels, we only need one 
 # linux version.
-matrix:
+jobs:
   include:
     - language: python
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ env:
 
 
 install:
+  # Print the Python version
+  - $PYTHON -VV
 
   # Install CleverCSV with the test dependencies (extra_requires)
   - $PIP install -e .[tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,4 @@ deploy:
   provider: script
   script: ls -1 wheelhouse && $PIP install twine && $PYTHON -m twine upload --verbose --skip-existing wheelhouse/*
   on:
-    if: (tag =~ /^v\d\.\d\.\d*/) and (branch = master)
+    condition: (tag =~ /^v\d\.\d\.\d$/) and (branch = master)

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,5 @@ deploy:
   provider: script
   script: ls -1 wheelhouse && $PIP install twine && $PYTHON -m twine upload --verbose --skip-existing wheelhouse/*
   on:
-    condition: (tag =~ /^v\d\.\d\.\d$/) and (branch = master)
+    branch: master
+    condition: $TRAVIS_TAG =~ ^v[0-9]\.[0-9]\.[0-9]$

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
 
 
 script:
-  - if [ ! -z "${TRAVIS_TAG:-}" ]; then
+  - if [[ "${TRAVIS_TAG:-}" =~ ^v[0-9]\.[0-9]\.[0-9].*$ ]]; then
       $PIP install cibuildwheel==1.0.0 && cibuildwheel --output-dir wheelhouse && ls -1 wheelhouse;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,6 @@ env:
 
 
 install:
-  # On Mac, ensure we have the latest version of Python (to run cibuildwheel)
-  - if [ "${TRAVIS_OS_NAME:-}" == "osx" ]; then
-      brew update;
-      brew upgrade python;
-    fi
 
   # Install CleverCSV with the test dependencies (extra_requires)
   - $PIP install -e .[tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,16 +66,9 @@ install:
 
 
 script:
-  script: 
-    # Install cibuildwheel
-    - $PIP install cibuildwheel==1.0.0
-    # Run cibuildwheel
-    - cibuildwheel --output-dir wheelhouse
-    # List the results
-    - ls wheelhouse
-  on:
-    # Only run on pre-release versions
-    if: (tag =~ /^v\d\.\d\.\d.*/) and (branch = master)
+  - if [ ! -z "${TRAVIS_TAG:-}" ]; then
+      $PIP install cibuildwheel==1.0.0 && cibuildwheel --output-dir wheelhouse && ls -1 wheelhouse;
+    fi
 
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
At the moment, we're running cibuildwheel on every commit. While this is thorough, it's not really necessary and it causes Travis to run for a long time.

With this PR we change this behaviour so that cibuildwheel is only run when the package has a version tag. The intended use case is that pre-release tags will be used (i.e. ``v0.4.8-rc.1``) to build and test the wheels before release. The release script has been updated to reflect this.