### PR TITLE
Replace nan with None for skipped dialects

### DIFF
--- a/clevercsv/consistency.py
+++ b/clevercsv/consistency.py
@@ -69,11 +69,7 @@ def consistency_scores(data, dialects, skip=True, logger=print):
     for dialect in sorted(dialects):
         P = pattern_score(data, dialect)
         if P < Qmax and skip:
-            scores[dialect] = {
-                "pattern": P,
-                "type": float("nan"),
-                "Q": float("nan"),
-            }
+            scores[dialect] = {"pattern": P, "type": None, "Q": None}
             logger("%15r:\tP = %15.6f\tskip." % (dialect, P))
             continue
         T = type_score(data, dialect)
@@ -87,10 +83,10 @@ def consistency_scores(data, dialects, skip=True, logger=print):
 
 
 def get_best_set(scores):
-    H = set()
-    Qmax = max((score["Q"] for score in scores.values()))
-    H = set([d for d, score in scores.items() if score["Q"] == Qmax])
-    return H
+    Qscores = [score["Q"] for score in scores.values()]
+    Qscores = filter(lambda q: not q is None, Qscores)
+    Qmax = max(Qscores)
+    return set([d for d, score in scores.items() if score["Q"] == Qmax])
 
 
 def break_ties(data, dialects):

--- a/tests/test_unit/test_consistency.py
+++ b/tests/test_unit/test_consistency.py
@@ -17,7 +17,7 @@ class ConsistencyTestCase(unittest.TestCase):
     def test_get_best_set_1(self):
         scores = {
             SimpleDialect(",", None, None): {"Q": 1.0},
-            SimpleDialect(";", None, None): {"Q": float("nan")},
+            SimpleDialect(";", None, None): {"Q": None},
             SimpleDialect("|", None, None): {"Q": 2.0},
         }
         H = get_best_set(scores)
@@ -25,7 +25,7 @@ class ConsistencyTestCase(unittest.TestCase):
 
     def test_get_best_set_2(self):
         scores = {
-            SimpleDialect(";", None, None): {"Q": float("nan")},
+            SimpleDialect(";", None, None): {"Q": None},
             SimpleDialect(",", None, None): {"Q": 1.0},
             SimpleDialect("|", None, None): {"Q": 2.0},
         }

--- a/tests/test_unit/test_consistency.py
+++ b/tests/test_unit/test_consistency.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit test for consistency score
+
+Author: G.J.J. van den Burg
+
+"""
+
+import unittest
+
+from clevercsv.consistency import get_best_set
+from clevercsv.dialect import SimpleDialect
+
+
+class ConsistencyTestCase(unittest.TestCase):
+    def test_get_best_set_1(self):
+        scores = {
+            SimpleDialect(",", None, None): {"Q": 1.0},
+            SimpleDialect(";", None, None): {"Q": float("nan")},
+            SimpleDialect("|", None, None): {"Q": 2.0},
+        }
+        H = get_best_set(scores)
+        self.assertEqual(H, set([SimpleDialect("|", None, None)]))
+
+    def test_get_best_set_2(self):
+        scores = {
+            SimpleDialect(";", None, None): {"Q": float("nan")},
+            SimpleDialect(",", None, None): {"Q": 1.0},
+            SimpleDialect("|", None, None): {"Q": 2.0},
+        }
+        H = get_best_set(scores)
+        self.assertEqual(H, set([SimpleDialect("|", None, None)]))


### PR DESCRIPTION
This PR fixes the issue raised in #5 

The original code used ``float('nan')`` as a placeholder for a dialect that can be skipped. The issue with this is that if the *first* dialect in the list has a Q-score of ``nan``, then the maximum over scores will return ``nan`` as well (see #5). The solution is to filter out these dialects before computing the maximum. We also replace ``nan`` by ``None`` since it make the code easier to understand.