### PR TITLE
Add stream_csv wrapper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ easier. We currently have the following helper functions:
   takes a path to a CSV file and returns the detected dialect
 * [read_csv](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.read_csv): 
   automatically detects the dialect and encoding of the file, and returns the 
-  data as a list of rows.
+  data as a list of rows. A version that returns a generator is also 
+  available: 
+  [stream_csv](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.stream_csv)
 * [csv2df](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.csv2df): 
   detects the dialect and encoding of the file and then uses Pandas to read 
   the CSV into a DataFrame.

--- a/clevercsv/__init__.py
+++ b/clevercsv/__init__.py
@@ -10,5 +10,12 @@ from .detect import Detector as Sniffer
 from .dict_read_write import DictReader, DictWriter
 from .exceptions import Error
 from .read import reader
-from .wrappers import detect_dialect, csv2df, read_as_dicts, read_csv, write_table
+from .wrappers import (
+    detect_dialect,
+    csv2df,
+    read_csv,
+    read_as_dicts,
+    stream_csv,
+    write_table,
+)
 from .write import writer


### PR DESCRIPTION
This is synonymous with ``wrappers.read_csv``, but returns a generator over the rows instead of a list.

Feature requested over email.