### PR TITLE
Add an option to drop into interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ CleverCSV (see above).*
 
 The ``clevercsv`` command line application has a number of handy features to 
 make working with CSV files easier. For instance, it can be used to view a CSV 
-file on the command line while automatically detecting the dialect.  It can 
+file on the command line while automatically detecting the dialect. It can 
 also generate Python code for importing data from a file with the correct 
 dialect. The full help text is as follows:
 
@@ -183,17 +183,18 @@ GLOBAL OPTIONS
   -V (--version)  Display the application version.
 
 AVAILABLE COMMANDS
-  code            Generate Python code for importing the CSV file.
+  code            Generate Python code for importing the CSV file
   detect          Detect the dialect of a CSV file
+  explore         Drop into a Python shell with the CSV file loaded
   help            Display the manual of a command
-  standardize     Convert a CSV file to one that conforms to RFC-4180.
+  standardize     Convert a CSV file to one that conforms to RFC-4180
   view            View the CSV file on the command line using TabView
 ```
 
-Each of the commands has further options (for instance, the ``code`` command 
-can generate code for importing a Pandas DataFrame). Use
-``clevercsv help <command>`` for more information. Below are some examples for 
-each command:
+Each of the commands has further options (for instance, the ``code`` and 
+``explore`` commands have support for importing the CSV file as a Pandas 
+DataFrame). Use ``clevercsv help <command>`` for more information. Below are 
+some examples for each command:
 
 #### Code
 
@@ -242,6 +243,43 @@ $ clevercsv detect --plain imdb.csv
 delimiter = ,
 quotechar =
 escapechar = \
+```
+
+#### Explore
+
+The ``explore`` command is great for a command-line based workflow, or when 
+you quickly want to start working with a CSV file in Python. This command 
+detects the dialect of a CSV file and starts an interactive Python shell with 
+the file already loaded! You can either have the file loaded as a list of 
+lists:
+
+```text
+$ clevercsv explore milk.csv
+Dropping you into an interactive shell.
+
+CleverCSV has loaded the data into the variable: rows
+>>>
+>>> len(rows)
+381
+```
+
+or you can load the file as a Pandas dataframe:
+
+```text
+$ clevercsv explore -p imdb.csv
+Dropping you into an interactive shell.
+
+CleverCSV has loaded the data into the variable: df
+>>>
+>>> df.head()
+                   fn        tid  ... War Western
+0  titles01/tt0012349  tt0012349  ...   0       0
+1  titles01/tt0015864  tt0015864  ...   0       0
+2  titles01/tt0017136  tt0017136  ...   0       0
+3  titles01/tt0017925  tt0017925  ...   0       0
+4  titles01/tt0021749  tt0021749  ...   0       0
+
+[5 rows x 44 columns]
 ```
 
 #### Standardize

--- a/clevercsv/console/application.py
+++ b/clevercsv/console/application.py
@@ -12,6 +12,7 @@ from .config import Config
 from .commands import (
     CodeCommand,
     DetectCommand,
+    ExploreCommand,
     StandardizeCommand,
     ViewCommand,
 )
@@ -24,4 +25,5 @@ def build_application():
     app.add(DetectCommand())
     app.add(StandardizeCommand())
     app.add(CodeCommand())
+    app.add(ExploreCommand())
     return app

--- a/clevercsv/console/commands/__init__.py
+++ b/clevercsv/console/commands/__init__.py
@@ -2,5 +2,6 @@
 
 from .code import CodeCommand
 from .detect import DetectCommand
+from .explore import ExploreCommand
 from .standardize import StandardizeCommand
 from .view import ViewCommand

--- a/clevercsv/console/commands/_utils.py
+++ b/clevercsv/console/commands/_utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from clevercsv import __version__
+
 
 def parse_int(val, name):
     """Parse a number to an integer if possible"""
@@ -11,3 +13,32 @@ def parse_int(val, name):
         raise ValueError(
             f"Please provide a number for {name}, instead of {val}"
         )
+
+
+def generate_code(filename, dialect, encoding, use_pandas=False):
+    d = '"\\t"' if dialect.delimiter == "\t" else f'"{dialect.delimiter}"'
+    q = '"%s"' % (dialect.quotechar.replace('"', '\\"'))
+    e = repr(f"{dialect.escapechar}").replace("'", '"')
+    base = [
+        "",
+        f"# Code generated with CleverCSV version {__version__}",
+        "",
+        "import clevercsv",
+    ]
+    if use_pandas:
+        return base + [
+            "",
+            f'df = clevercsv.csv2df("{filename}", delimiter={d}, quotechar={q}, escapechar={e})',
+            "",
+        ]
+
+    enc = "None" if encoding is None else f'"{encoding}"'
+    lines = base + [
+            "",
+            f'with open("{filename}", "r", newline="", encoding={enc}) as fp:',
+            "    reader = clevercsv.reader(fp, "
+            + f"delimiter={d}, quotechar={q}, escapechar={e})",
+            "    rows = list(reader)",
+            "",
+    ]
+    return lines

--- a/clevercsv/console/commands/code.py
+++ b/clevercsv/console/commands/code.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import code
-
 from cleo import Command
 
-from clevercsv import __version__
 from clevercsv.utils import get_encoding
 from clevercsv.wrappers import detect_dialect
 
-from ._utils import parse_int
+from ._utils import parse_int, generate_code
 
 
 class CodeCommand(Command):
@@ -18,7 +15,7 @@ class CodeCommand(Command):
     code
         { path : The path to the CSV file }
         { --e|encoding= : Set the encoding of the CSV file. }
-        { --i|interact : Drop into a Pyohon interactive shell. }
+        { --i|interact : Drop into a Python interactive shell. }
         { --n|num-chars= : Limit the number of characters to read for
         detection. This will speed up detection but may reduce accuracy. }
         { --p|pandas : Write code that imports to a Pandas DataFrame }
@@ -47,47 +44,8 @@ and copy the generated code to a Python script.
         if dialect is None:
             return self.line("Dialect detection failed.")
 
-        d = '"\\t"' if dialect.delimiter == "\t" else f'"{dialect.delimiter}"'
-        q = '"%s"' % (dialect.quotechar.replace('"', '\\"'))
-        e = repr(f"{dialect.escapechar}").replace("'", '"')
-        base = [
-            "",
-            f"# Code generated with CleverCSV version {__version__}",
-            "",
-            "import clevercsv",
-        ]
-        if self.option("pandas"):
-            thecode = base + [
-                "",
-                f'df = clevercsv.csv2df("{filename}", delimiter={d}, quotechar={q}, escapechar={e})',
-                "",
-            ]
-        else:
-            enc = "None" if encoding is None else f'"{encoding}"'
-            thecode = base + [
-                "",
-                f'with open("{filename}", "r", newline="", encoding={enc}) as fp:',
-                "    reader = clevercsv.reader(fp, "
-                + f"delimiter={d}, quotechar={q}, escapechar={e})",
-                "    rows = list(reader)",
-                "",
-            ]
+        code_lines = generate_code(
+            filename, dialect, encoding, use_pandas=self.option("pandas")
+        )
 
-        if not self.option("interact"):
-            self.line("\n".join(thecode))
-            return
-
-        console = code.InteractiveConsole()
-        for line in thecode:
-            retcode = console.push(line)
-        if retcode:
-            self.line(
-                "An error occurred starting the interactive console. "
-                "Printing commands instead:\n"
-            )
-            self.line("\n".join(thecode))
-            return
-        self.line("Dropping you into an interactive shell.\n")
-        banner = "CleverCSV has loaded the data into the variable: "
-        banner += "df" if self.option("pandas") else "rows"
-        console.interact(banner=banner)
+        self.line("\n".join(code_lines))

--- a/clevercsv/console/commands/explore.py
+++ b/clevercsv/console/commands/explore.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+import code
+
+from cleo import Command
+
+from clevercsv.utils import get_encoding
+from clevercsv.wrappers import detect_dialect
+
+from ._utils import parse_int, generate_code
+
+
+class ExploreCommand(Command):
+    """
+    Drop into a Python shell with the CSV file loaded
+
+    explore
+        { path : The path to the CSV file }
+        { --e|encoding= : Set the encoding of the CSV file. }
+        { --n|num-chars= : Limit the number of characters to read for 
+        detection. This will speed up detection for large files, but may reduce 
+        accuracy. }
+        { --p|pandas : Read file into a Pandas dataframe. }
+    """
+
+    help = """\
+The <info>explore</info> command allows you to quickly explore a CSV file in an 
+interactive Python shell. This command detects the dialect of the CSV file and 
+drops you into a Python interactive shell (REPL), with the CSV file already 
+loaded. Simply run:
+
+clevercsv explore FILE
+
+to start working with the file loaded as a list of lists. Alternatively, you 
+can run
+
+clevercsv explore -p FILE
+
+to read the file as a Pandas dataframe.
+"""
+
+    def handle(self):
+        filename = self.argument("path")
+        encoding = self.option("encoding") or get_encoding(filename)
+        num_chars = parse_int(self.option("num-chars"), "num-chars")
+        dialect = detect_dialect(
+            filename,
+            num_chars=num_chars,
+            encoding=encoding,
+            verbose=self.option("verbose"),
+        )
+        if dialect is None:
+            return self.line("Dialect detection failed.")
+
+        code_lines = generate_code(
+            filename, dialect, encoding, use_pandas=self.option("pandas")
+        )
+
+        console = code.InteractiveConsole()
+        for line in code_lines:
+            retcode = console.push(line)
+        if retcode:
+            self.line(
+                "An error occurred starting the interactive console. "
+                "Printing commands instead:\n"
+            )
+            self.line("\n".join(code_lines))
+            return
+        self.line("Dropping you into an interactive shell.\n")
+        banner = "CleverCSV has loaded the data into the variable: "
+        banner += "df" if self.option("pandas") else "rows"
+        console.interact(banner=banner)


### PR DESCRIPTION
This PR adds a feature to the CleverCSV command line interface that allows users to drop into a Python REPL with the file loaded. This seems like a useful addition to the ``code`` command to quickly start working on a file. The idea is that running

```
$  clevercsv code -i <filename>
```
or 
```
$ clevercsv code -i -p <filename>
```

gives you a Python interactive shell with the file loaded either as a list of lists or as a Pandas dataframe.