### PR TITLE
Separate into a "core" and "full" version of the package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - $PYTHON -VV
 
   # Install CleverCSV with the test dependencies (extra_requires)
-  - $PIP install -e .[tests]
+  - $PIP install -e .[full,tests]
 
   # Run the unit tests
   - $PYTHON -m unittest discover -v -f -s ./tests/test_unit

--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ GitHub](https://github.com/alan-turing-institute/CleverCSV)!
 
 ## Installation
 
-The package is available on PyPI:
+CleverCSV is available on PyPI. You can install either the full version, which 
+includes the command line interface and all optional dependencies, using
+
+```bash
+$ pip install clevercsv[full]
+```
+
+or you can install a lighter, core version of CleverCSV with
 
 ```bash
 $ pip install clevercsv
@@ -151,9 +158,12 @@ documentation](https://clevercsv.readthedocs.io/en/latest/source/modules.html).
 
 ### Command-Line Tool
 
+*To use the command line tool, make sure that you install the full version of 
+CleverCSV (see above).*
+
 The ``clevercsv`` command line application has a number of handy features to 
 make working with CSV files easier. For instance, it can be used to view a CSV 
-file on the command line while automatically detecting the dialect. It can 
+file on the command line while automatically detecting the dialect.  It can 
 also generate Python code for importing data from a file with the correct 
 dialect. The full help text is as follows:
 

--- a/clevercsv/__main__.py
+++ b/clevercsv/__main__.py
@@ -7,8 +7,16 @@ Caller for the command line application.
 
 import sys
 
+from ._optional import import_optional_dependency
+
 
 def main():
+    # Check that necessary dependencies are available
+    import_optional_dependency("cleo")
+    import_optional_dependency("clikit")
+    import_optional_dependency("tabview", raise_on_missing=False)
+
+    # if so, load the actual main function and call it.
     from .console import main as realmain
 
     sys.exit(realmain())

--- a/clevercsv/_optional.py
+++ b/clevercsv/_optional.py
@@ -11,8 +11,10 @@ License: See LICENSE file.
 
 """
 
+import distutils.version
 import importlib
 
+# update this when changing setup.py
 VERSIONS = {
     "cleo": "0.7.6",
     "clikit": "0.4.0",
@@ -32,7 +34,7 @@ def import_optional_dependency(name, raise_on_missing=True):
     name : str
         Name of the module to import
 
-    raise_on_missing: bool
+    raise_on_missing : bool
         Whether to raise an error when the package is missing or to simply 
         return None.
 
@@ -60,5 +62,20 @@ def import_optional_dependency(name, raise_on_missing=True):
             raise ImportError(msg) from None
         else:
             return None
+
+    min_version = VERSIONS.get(name)
+    if not min_version:
+        return module
+    version = getattr(module, "__version__", None)
+    if version is None:
+        return
+    if distutils.version.LooseVersion(version) < min_version:
+        msg = (
+            f"CleverCSV requires version '{min_version}' or newer for "
+            "optional dependency '{name}'. Please update the package "
+            "or install CleverCSV with all its optional dependencies "
+            "using: pip install clevercsv[full]"
+        )
+        raise ImportError(msg)
 
     return module

--- a/clevercsv/_optional.py
+++ b/clevercsv/_optional.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+"""Code for dealing with optional dependencies
+
+The functionality in this file is largely based on similar functionality in the 
+Pandas library.
+
+Author: G.J.J van den Burg
+Copyright: 2020, The Alan Turing Institute
+License: See LICENSE file.
+
+"""
+
+import importlib
+
+VERSIONS = {
+    "cleo": "0.7.6",
+    "clikit": "0.4.0",
+    "tabview": "1.4",
+    "pandas": "0.24.1",
+}
+
+
+def import_optional_dependency(name, raise_on_missing=True):
+    """
+    Import an optional dependency.
+
+    This function is modelled on a similar function in the Pandas library.
+
+    Parameters
+    ----------
+    name : str
+        Name of the module to import
+
+    raise_on_missing: bool
+        Whether to raise an error when the package is missing or to simply 
+        return None.
+
+    Returns
+    -------
+    module : module
+        The module if importing was successful, None if 
+        :attr:`raise_on_missing` is False.
+
+    Raises
+    ------
+    ImportError
+        When a module can't be imported and :attr:`raise_on_missing` is True.
+
+    """
+    msg = (
+        f"\nOptional dependency '{name}' is missing. You can install it using "
+        "pip or conda, or you can install CleverCSV with all of its optional "
+        "dependencies by running: pip install clevercsv[full]"
+    )
+    try:
+        module = importlib.import_module(name)
+    except ImportError:
+        if raise_on_missing:
+            raise ImportError(msg) from None
+        else:
+            return None
+
+    return module

--- a/clevercsv/console/commands/view.py
+++ b/clevercsv/console/commands/view.py
@@ -2,7 +2,7 @@
 
 try:
     import tabview
-except ModuleNotFoundError:
+except ImportError:
 
     class TabView:
         def view(*args, **kwargs):

--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -8,11 +8,9 @@ Author: Gertjan van den Burg
 """
 
 import os
-import pandas as pd
 import warnings
 
-from pandas.errors import ParserWarning
-
+from ._optional import import_optional_dependency
 from .detect import Detector
 from .dict_read_write import DictReader
 from .exceptions import NoDetectionResult
@@ -168,6 +166,7 @@ def csv2df(filename, *args, **kwargs):
     """
     if not (os.path.exists(filename) and os.path.isfile(filename)):
         raise ValueError("Filename must be a regular file")
+    pd = import_optional_dependency("pandas")
     enc = get_encoding(filename)
     with open(filename, "r", newline="", encoding=enc) as fid:
         dialect = Detector().detect(fid.read())
@@ -178,7 +177,7 @@ def csv2df(filename, *args, **kwargs):
         warnings.filterwarnings(
             "ignore",
             message="^Conflicting values for .*",
-            category=ParserWarning,
+            category=pd.errors.ParserWarning,
         )
         df = pd.read_csv(filename, *args, dialect=csv_dialect, **kwargs)
     return df

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,10 @@ REQUIRED = [
 full_require = [
     "pandas>=0.24.1",
     "tabview>=1.4",
-    "cleo==0.7.6",
-    "clikit==0.4.0",
+    "cleo>=0.7.6",
+    "clikit>=0.4.0",
 ]
+
 docs_require = ["sphinx", "m2r"]
 test_require = full_require + []
 dev_require = ["green", "pythonfuzz", "termcolor"]

--- a/setup.py
+++ b/setup.py
@@ -21,19 +21,23 @@ VERSION = None
 # What packages are required for this module to be executed?
 REQUIRED = [
     "chardet>=3.0",
-    "cleo==0.7.6",
-    "clikit==0.4.0",
-    "pandas>=0.24.1",
     "regex>=2018.11",
-    "tabview>=1.4",
 ]
 
+# When these are changed, update clevercsv/_optional.py accordingly
+full_require = [
+    "pandas>=0.24.1",
+    "tabview>=1.4",
+    "cleo==0.7.6",
+    "clikit==0.4.0",
+]
 docs_require = ["sphinx", "m2r"]
-test_require = []
+test_require = full_require + []
 dev_require = ["green", "pythonfuzz", "termcolor"]
 
 # What packages are optional?
 EXTRAS = {
+    "full": full_require,
     "docs": docs_require,
     "tests": test_require,
     "dev": docs_require + test_require + dev_require,


### PR DESCRIPTION
This commit follows a request for a lighter version of CleverCSV that does not include as many dependencies (#10). With this commit we create a "full" version by leveraging the extra_requires part
of the setup.py file, and leave the drop-in replacement of the csv library as the "core" package. To make the core version of the package lighter, I've also moved the command line interface dependencies to the full version of the package.