### PR TITLE
Add the num_chars argument to remaining wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,16 @@ import clevercsv
 
 with open("data.csv", "r", newline="") as fp:
   # you can use verbose=True to see what CleverCSV does
-  dialect = clevercsv.Sniffer().sniff(fid.read(), verbose=False)
+  dialect = clevercsv.Sniffer().sniff(fp.read(), verbose=False)
   fp.seek(0)
   reader = clevercsv.reader(fp, dialect)
   rows = list(reader)
+```
+
+For large files, you speed up detection by supplying a smaller sample to the 
+sniffer, for instance:
+```python
+dialect = clevercsv.Sniffer().sniff(fp.read(10000))
 ```
 
 That's the basics! If you want more details, you can look at the code of the 
@@ -194,7 +200,11 @@ AVAILABLE COMMANDS
 Each of the commands has further options (for instance, the ``code`` and 
 ``explore`` commands have support for importing the CSV file as a Pandas 
 DataFrame). Use ``clevercsv help <command>`` for more information. Below are 
-some examples for each command:
+some examples for each command.
+
+Note that each command accepts the ``-n`` or ``--num-chars`` flag to set the 
+number of characters used to detect the dialect. This can be especially 
+helpful to speed up dialect detection on large files.
 
 #### Code
 

--- a/tests/test_unit/test_wrappers.py
+++ b/tests/test_unit/test_wrappers.py
@@ -19,7 +19,7 @@ from clevercsv.exceptions import NoDetectionResult
 
 
 class WrappersTestCase(unittest.TestCase):
-    def _df_test(self, table, dialect):
+    def _df_test(self, table, dialect, **kwargs):
         tmpfd, tmpfname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
         tmpid = os.fdopen(tmpfd, "w")
         w = writer(tmpid, dialect=dialect)
@@ -107,6 +107,12 @@ class WrappersTestCase(unittest.TestCase):
         dialect = SimpleDialect(delimiter=",", quotechar='"', escapechar="")
         with self.subTest(name="double"):
             self._df_test(table, dialect)
+
+        table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
+        dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
+        with self.subTest(name="simple_nchar"):
+            self._df_test(table, dialect, num_char=10)
+
 
     def test_read_csv(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]


### PR DESCRIPTION
The ``read_as_dicts`` and ``csv2df`` wrappers didn't yet have a ``num_chars`` argument. This PR addresses that.