### PR TITLE
Wrapper rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,20 @@ easier. We currently have the following helper functions:
 
 * [detect_dialect](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.detect_dialect): 
   takes a path to a CSV file and returns the detected dialect
-* [read_csv](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.read_csv): 
+* [read_table](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.read_table): 
   automatically detects the dialect and encoding of the file, and returns the 
   data as a list of rows. A version that returns a generator is also 
   available: 
-  [stream_csv](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.stream_csv)
-* [csv2df](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.csv2df): 
+  [stream_table](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.stream_table)
+* [read_dataframe](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.read_dataframe): 
   detects the dialect and encoding of the file and then uses 
   [Pandas](https://pandas.pydata.org/) to read the CSV into a DataFrame. Note 
   that this function requires Pandas to be installed.
+* [read_dicts](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.read_dicts): 
+  detect the dialect and return the rows of the file as dictionaries, assuming 
+  the first row contains the headers. A streaming version called 
+  [stream_dicts](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.stream_dicts) 
+  is also available.
 * [write_table](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.write_table): 
   write a table (a list of lists) to a file using the RFC-4180 dialect.
 

--- a/clevercsv/__init__.py
+++ b/clevercsv/__init__.py
@@ -20,3 +20,6 @@ from .wrappers import (
     write_table,
 )
 from .write import writer
+
+# outdated, to be removed in 0.7.0
+from .wrappers import read_as_dicts, read_csv, stream_csv, csv2df

--- a/clevercsv/__init__.py
+++ b/clevercsv/__init__.py
@@ -12,10 +12,11 @@ from .exceptions import Error
 from .read import reader
 from .wrappers import (
     detect_dialect,
-    csv2df,
-    read_csv,
-    read_as_dicts,
-    stream_csv,
+    read_dataframe,
+    read_dicts,
+    read_table,
+    stream_dicts,
+    stream_table,
     write_table,
 )
 from .write import writer

--- a/clevercsv/console/commands/_utils.py
+++ b/clevercsv/console/commands/_utils.py
@@ -28,7 +28,7 @@ def generate_code(filename, dialect, encoding, use_pandas=False):
     if use_pandas:
         return base + [
             "",
-            f'df = clevercsv.csv2df("{filename}", delimiter={d}, quotechar={q}, escapechar={e})',
+            f'df = clevercsv.read_dataframe("{filename}", delimiter={d}, quotechar={q}, escapechar={e})',
             "",
         ]
 

--- a/clevercsv/console/commands/view.py
+++ b/clevercsv/console/commands/view.py
@@ -7,13 +7,14 @@ except ImportError:
     class TabView:
         def view(*args, **kwargs):
             print("Unfortunately Tabview is not available on Windows.")
+
     tabview = TabView()
 
 
 from cleo import Command
 
 from clevercsv.exceptions import NoDetectionResult
-from clevercsv.wrappers import read_csv
+from clevercsv.wrappers import read_table
 
 from ._utils import parse_int
 
@@ -38,7 +39,7 @@ Use the <info>view</info> command to view a CSV file on the command line.
         verbose = self.io.verbosity > 0
         num_chars = parse_int(self.option("num-chars"), "num-chars")
         try:
-            rows = read_csv(
+            rows = read_table(
                 self.argument("path"),
                 encoding=self.option("encoding"),
                 num_chars=num_chars,

--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -19,9 +19,50 @@ from .utils import get_encoding
 from .write import writer
 
 
-def read_as_dicts(
+def stream_dicts(
     filename, dialect=None, encoding=None, num_chars=None, verbose=False
 ):
+    """Read a CSV file as a generator over dictionaries
+
+    This function streams the rows of the CSV file as dictionaries. The keys of 
+    the dictionaries are assumed to be in the first row of the CSV file. The 
+    dialect will be detected automatically, unless it is provided.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the CSV file
+
+    dialect : str, SimpleDialect, or csv.Dialect object
+        If the dialect is known, it can be provided here. This function uses 
+        the Clevercsv :class:``DictReader`` object, which supports various 
+        dialect types (string, SimpleDialect, or csv.Dialect). If None, the 
+        dialect will be detected.
+
+    encoding : str
+        The encoding of the file. If None, it is detected.
+
+    num_chars : int
+        Number of characters to use to detect the dialect. If None, use the 
+        entire file.
+
+        Note that using less than the entire file will speed up detection, but 
+        can reduce the accuracy of the detected dialect.
+
+    verbose: bool
+        Whether or not to show detection progress.
+
+    Returns
+    -------
+    rows: generator
+        Returns file as a generator over rows as dictionaries.
+
+    Raises
+    ------
+    NoDetectionResult
+        When the dialect detection fails.
+
+    """
     if encoding is None:
         encoding = get_encoding(filename)
     with open(filename, "r", newline="", encoding=encoding) as fid:
@@ -34,10 +75,101 @@ def read_as_dicts(
             yield row
 
 
+def read_dicts(
+    filename, dialect=None, encoding=None, num_chars=None, verbose=False
+):
+    """Read a CSV file as a list of dictionaries
+
+    This function returns the rows of the CSV file as a list of dictionaries.  
+    The keys of the dictionaries are assumed to be in the first row of the CSV 
+    file. The dialect will be detected automatically, unless it is provided.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the CSV file
+
+    dialect : str, SimpleDialect, or csv.Dialect object
+        If the dialect is known, it can be provided here. This function uses 
+        the Clevercsv :class:``DictReader`` object, which supports various 
+        dialect types (string, SimpleDialect, or csv.Dialect). If None, the 
+        dialect will be detected.
+
+    encoding : str
+        The encoding of the file. If None, it is detected.
+
+    num_chars : int
+        Number of characters to use to detect the dialect. If None, use the 
+        entire file.
+
+        Note that using less than the entire file will speed up detection, but 
+        can reduce the accuracy of the detected dialect.
+
+    verbose: bool
+        Whether or not to show detection progress.
+
+    Returns
+    -------
+    rows: list
+        Returns rows of the file as a list of dictionaries.
+
+    Raises
+    ------
+    NoDetectionResult
+        When the dialect detection fails.
+
+    """
+    return list(
+        stream_dicts(
+            filename,
+            dialect=dialect,
+            encoding=encoding,
+            num_chars=num_chars,
+            verbose=verbose,
+        )
+    )
+
+
+def read_as_dicts(
+    filename, dialect=None, encoding=None, num_chars=None, verbose=False
+):
+    """This function is deprecated, use read_as_dicts instead."""
+    warnings.warn(
+        "'read_as_dicts' was renamed to 'read_dicts' in version "
+        "0.6.3 and will be removed in 0.7.0.",
+        FutureWarning,
+    )
+    return read_dicts(
+        filename,
+        dialect=dialect,
+        encoding=encoding,
+        num_chars=num_chars,
+        verbose=verbose,
+    )
+
+
 def read_csv(
     filename, dialect=None, encoding=None, num_chars=None, verbose=False,
 ):
-    """Read a CSV file as a list of lists
+    """This function is deprecated, use read_table instead."""
+    warnings.warn(
+        "'read_csv' was renamed to 'read_table' in version "
+        "0.6.3 and will be removed in 0.7.0.",
+        FutureWarning,
+    )
+    return read_table(
+        filename,
+        dialect=dialect,
+        encoding=encoding,
+        num_chars=num_chars,
+        verbose=verbose,
+    )
+
+
+def read_table(
+    filename, dialect=None, encoding=None, num_chars=None, verbose=False,
+):
+    """Read a CSV file as a table (a list of lists)
 
     This is a convenience function that reads a CSV file and returns the data 
     as a list of lists (= rows). The dialect will be detected automatically, 
@@ -79,7 +211,7 @@ def read_csv(
 
     """
     return list(
-        stream_csv(
+        stream_table(
             filename,
             dialect=dialect,
             encoding=encoding,
@@ -92,7 +224,25 @@ def read_csv(
 def stream_csv(
     filename, dialect=None, encoding=None, num_chars=None, verbose=False,
 ):
-    """Read a CSV file as a generator over rows
+    """This function is deprecated, use stream_table instead."""
+    warnings.warn(
+        "'stream_csv' was renamed to 'stream_table' in version "
+        "0.6.3 and will be removed in 0.7.0.",
+        FutureWarning,
+    )
+    yield from stream_table(
+        filename,
+        dialect=dialect,
+        encoding=encoding,
+        num_chars=num_chars,
+        verbose=verbose,
+    )
+
+
+def stream_table(
+    filename, dialect=None, encoding=None, num_chars=None, verbose=False,
+):
+    """Read a CSV file as a generator over rows of a table
 
     This is a convenience function that reads a CSV file and returns the data 
     as a generator of rows. The dialect will be detected automatically, unless 
@@ -147,6 +297,16 @@ def stream_csv(
 
 
 def csv2df(filename, *args, num_chars=None, **kwargs):
+    """This function is deprecated, use read_dataframe instead."""
+    warnings.warn(
+        "'csv2df' was renamed to 'read_dataframe' in version "
+        "0.6.3 and will be removed in 0.7.0.",
+        FutureWarning,
+    )
+    return read_dataframe(filename, *args, num_chars=num_chars, **kwargs)
+
+
+def read_dataframe(filename, *args, num_chars=None, **kwargs):
     """ Read a CSV file to a Pandas dataframe
 
     This function uses CleverCSV to detect the dialect, and then passes this to 

--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -339,7 +339,11 @@ def read_dataframe(filename, *args, num_chars=None, **kwargs):
     if not (os.path.exists(filename) and os.path.isfile(filename)):
         raise ValueError("Filename must be a regular file")
     pd = import_optional_dependency("pandas")
+
+    # Use provided encoding or detect it, and record it for pandas
     enc = kwargs.get("encoding") or get_encoding(filename)
+    kwargs["encoding"] = enc
+
     with open(filename, "r", newline="", encoding=enc) as fid:
         data = fid.read(num_chars) if num_chars else fid.read()
         dialect = Detector().detect(data)

--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -182,9 +182,9 @@ def read_table(
 
     dialect: str, SimpleDialect, or csv.Dialect object
         If the dialect is known, it can be provided here. This function uses 
-        the CleverCSV :class:``reader`` object, which supports various dialect 
-        types (string, SimpleDialect, or csv.Dialect). If None, the dialect 
-        will be detected.
+        the CleverCSV :class:`clevercsv.reader` object, which supports various 
+        dialect types (string, SimpleDialect, or csv.Dialect). If None, the 
+        dialect will be detected.
 
     encoding : str
         The encoding of the file. If None, it is detected.
@@ -255,9 +255,9 @@ def stream_table(
 
     dialect: str, SimpleDialect, or csv.Dialect object
         If the dialect is known, it can be provided here. This function uses 
-        the CleverCSV :class:``reader`` object, which supports various dialect 
-        types (string, SimpleDialect, or csv.Dialect). If None, the dialect 
-        will be detected.
+        the CleverCSV :class:`clevercsv.reader` object, which supports various 
+        dialect types (string, SimpleDialect, or csv.Dialect). If None, the 
+        dialect will be detected.
 
     encoding : str
         The encoding of the file. If None, it is detected.

--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -331,13 +331,15 @@ def read_dataframe(filename, *args, num_chars=None, **kwargs):
         can reduce the accuracy of the detected dialect.
 
     **kwargs:
-        Additional keyword arguments for the ``pandas.read_csv`` function.
+        Additional keyword arguments for the ``pandas.read_csv`` function. You 
+        can specify the file encoding here if needed, and it will be used 
+        during dialect detection.
 
     """
     if not (os.path.exists(filename) and os.path.isfile(filename)):
         raise ValueError("Filename must be a regular file")
     pd = import_optional_dependency("pandas")
-    enc = get_encoding(filename)
+    enc = kwargs.get("encoding") or get_encoding(filename)
     with open(filename, "r", newline="", encoding=enc) as fid:
         data = fid.read(num_chars) if num_chars else fid.read()
         dialect = Detector().detect(data)

--- a/tests/test_unit/test_console.py
+++ b/tests/test_unit/test_console.py
@@ -164,7 +164,7 @@ with open("{tmpfname}", "r", newline="", encoding="ascii") as fp:
 
 import clevercsv
 
-df = clevercsv.csv2df("{tmpfname}", delimiter=";", quotechar="", escapechar="")
+df = clevercsv.read_dataframe("{tmpfname}", delimiter=";", quotechar="", escapechar="")
 
 """
         try:

--- a/tests/test_unit/test_wrappers.py
+++ b/tests/test_unit/test_wrappers.py
@@ -21,7 +21,7 @@ from clevercsv.exceptions import NoDetectionResult
 class WrappersTestCase(unittest.TestCase):
     def _df_test(self, table, dialect, **kwargs):
         tmpfd, tmpfname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
-        tmpid = os.fdopen(tmpfd, "w")
+        tmpid = os.fdopen(tmpfd, "w", encoding=kwargs.get("encoding"))
         w = writer(tmpid, dialect=dialect)
         w.writerows(table)
         tmpid.close()
@@ -112,6 +112,11 @@ class WrappersTestCase(unittest.TestCase):
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
         with self.subTest(name="simple_nchar"):
             self._df_test(table, dialect, num_char=10)
+
+        table = [["Ä", "Ð", "Ç"], [1, 2, 3], [4, 5, 6]]
+        dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
+        with self.subTest(name="simple_encoding"):
+            self._df_test(table, dialect, num_char=10, encoding="latin1")
 
     def test_read_table(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]

--- a/tests/test_unit/test_wrappers.py
+++ b/tests/test_unit/test_wrappers.py
@@ -27,7 +27,7 @@ class WrappersTestCase(unittest.TestCase):
         tmpid.close()
 
         exp_df = pd.DataFrame.from_records(table[1:], columns=table[0])
-        df = wrappers.csv2df(tmpfname)
+        df = wrappers.read_dataframe(tmpfname)
 
         try:
             self.assertTrue(df.equals(exp_df))
@@ -47,7 +47,7 @@ class WrappersTestCase(unittest.TestCase):
         tmpfname = self._write_tmpfile(table, dialect)
         exp = [list(map(str, r)) for r in table]
         try:
-            self.assertEqual(exp, wrappers.read_csv(tmpfname))
+            self.assertEqual(exp, wrappers.read_table(tmpfname))
         finally:
             os.unlink(tmpfname)
 
@@ -55,7 +55,7 @@ class WrappersTestCase(unittest.TestCase):
         tmpfname = self._write_tmpfile(table, dialect)
         exp = [list(map(str, r)) for r in table]
         try:
-            out = wrappers.stream_csv(tmpfname)
+            out = wrappers.stream_table(tmpfname)
             self.assertTrue(isinstance(out, types.GeneratorType))
             self.assertEqual(exp, list(out))
         finally:
@@ -69,7 +69,7 @@ class WrappersTestCase(unittest.TestCase):
         tmpid.close()
 
         try:
-            self.assertEqual(expected, wrappers.read_csv(tmpfname))
+            self.assertEqual(expected, wrappers.read_table(tmpfname))
         finally:
             os.unlink(tmpfname)
 
@@ -81,13 +81,13 @@ class WrappersTestCase(unittest.TestCase):
         tmpid.close()
 
         try:
-            out = wrappers.stream_csv(tmpfname)
+            out = wrappers.stream_table(tmpfname)
             self.assertTrue(isinstance(out, types.GeneratorType))
             self.assertEqual(expected, list(out))
         finally:
             os.unlink(tmpfname)
 
-    def test_csv2df(self):
+    def test_read_dataframe(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
         with self.subTest(name="simple"):
@@ -113,8 +113,7 @@ class WrappersTestCase(unittest.TestCase):
         with self.subTest(name="simple_nchar"):
             self._df_test(table, dialect, num_char=10)
 
-
-    def test_read_csv(self):
+    def test_read_table(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
         with self.subTest(name="simple"):
@@ -149,7 +148,7 @@ class WrappersTestCase(unittest.TestCase):
             with self.assertRaises(NoDetectionResult):
                 self._read_test_rows(rows, exp)
 
-    def test_stream_csv(self):
+    def test_stream_table(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
         with self.subTest(name="simple"):


### PR DESCRIPTION
This PR makes the wrapper names more coherent, and specifies that the old names will be removed in version 0.7.0. Hopefully this will give people some time to adapt. It also adds a natural "stream_dicts" wrapper function and adds a fix that allows users to specify the encoding used in the ``read_dataframe`` wrapper.