### PR TITLE
Raise dependency warning for TabView on non-Windows platforms

### DIFF
--- a/clevercsv/__main__.py
+++ b/clevercsv/__main__.py
@@ -14,7 +14,9 @@ def main():
     # Check that necessary dependencies are available
     import_optional_dependency("cleo")
     import_optional_dependency("clikit")
-    import_optional_dependency("tabview", raise_on_missing=False)
+    import_optional_dependency(
+        "tabview", raise_on_missing=not sys.platform == "win32"
+    )
 
     # if so, load the actual main function and call it.
     from .console import main as realmain


### PR DESCRIPTION
TabView is not available on Windows, and this is handled in the view command. But the previous behavior was to warn the user of this even if the platform would support TabView, which this PR fixes.