### PR TITLE
Add warning for duplicate fieldnames in DictReader

### DIFF
--- a/clevercsv/dict_read_write.py
+++ b/clevercsv/dict_read_write.py
@@ -10,6 +10,8 @@ Author: Gertjan van den Burg
 
 """
 
+import warnings
+
 from collections import OrderedDict
 
 from .read import reader
@@ -44,6 +46,18 @@ class DictReader(object):
                 self._fieldnames = next(self.reader)
             except StopIteration:
                 pass
+
+        # Note: this was added because I don't think it's expected that Python
+        # simply drops information if there are duplicate headers. There is
+        # discussion on this issue in the Python bug tracker here:
+        # https://bugs.python.org/issue17537 (see linked thread therein). A
+        # warning is easy enough to suppress and should ensure that the user
+        # is at least aware of this behavior.
+        if not len(self._fieldnames) == len(set(self._fieldnames)):
+            warnings.warn(
+                "fieldnames are not unique, some columns will be dropped."
+            )
+
         self.line_num = self.reader.line_num
         return self._fieldnames
 

--- a/clevercsv/dict_read_write.py
+++ b/clevercsv/dict_read_write.py
@@ -92,7 +92,7 @@ class DictWriter(object):
 
     def writeheader(self):
         header = dict(zip(self.fieldnames, self.fieldnames))
-        self.writerow(header)
+        return self.writerow(header)
 
     def _dict_to_list(self, rowdict):
         if self.extrasaction == "raise":

--- a/clevercsv/write.py
+++ b/clevercsv/write.py
@@ -51,12 +51,12 @@ class writer(object):
 
     def writerow(self, row):
         try:
-            self._writer.writerow(row)
+            return self._writer.writerow(row)
         except csv.Error as e:
             raise Error(str(e))
 
     def writerows(self, rows):
         try:
-            self._writer.writerows(rows)
+            return self._writer.writerows(rows)
         except csv.Error as e:
             raise Error(str(e))

--- a/tests/test_unit/test_dict.py
+++ b/tests/test_unit/test_dict.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for the DictReader and DictWriter classes
+
+Most of these are the same as in CPython, but we also test the cases where 
+CleverCSV's behavior differs.
+
+"""
+
+import clevercsv
+import io
+import tempfile
+import unittest
+
+
+class DictTestCase(unittest.TestCase):
+
+    ############################
+    # Start tests from CPython #
+
+    def test_writeheader_return_value(self):
+        with tempfile.TemporaryFile("w+", newline="") as fp:
+            writer = clevercsv.DictWriter(fp, fieldnames=["f1", "f2", "f3"])
+            writeheader_return_value = writer.writeheader()
+            self.assertEqual(writeheader_return_value, 10)
+
+    def test_write_simple_dict(self):
+        with tempfile.TemporaryFile("w+", newline="") as fp:
+            writer = clevercsv.DictWriter(fp, fieldnames=["f1", "f2", "f3"])
+            writer.writeheader()
+            fp.seek(0)
+            self.assertEqual(fp.readline(), "f1,f2,f3\r\n")
+            writer.writerow({"f1": 10, "f3": "abc"})
+            fp.seek(0)
+            fp.readline()  # header
+            self.assertEqual(fp.read(), "10,,abc\r\n")
+
+    def test_write_multiple_dict_rows(self):
+        fp = io.StringIO()
+        writer = clevercsv.DictWriter(fp, fieldnames=["f1", "f2", "f3"])
+        writer.writeheader()
+        self.assertEqual(fp.getvalue(), "f1,f2,f3\r\n")
+        writer.writerows(
+            [
+                {"f1": 1, "f2": "abc", "f3": "f"},
+                {"f1": 2, "f2": 5, "f3": "xyz"},
+            ]
+        )
+        self.assertEqual(fp.getvalue(), "f1,f2,f3\r\n1,abc,f\r\n2,5,xyz\r\n")
+
+    def test_write_no_fields(self):
+        fp = io.StringIO()
+        self.assertRaises(TypeError, clevercsv.DictWriter, fp)
+
+    def test_write_fields_not_in_fieldnames(self):
+        with tempfile.TemporaryFile("w+", newline="") as fp:
+            writer = clevercsv.DictWriter(fp, fieldnames=["f1", "f2", "f3"])
+            # Of special note is the non-string key (CPython issue 19449)
+            with self.assertRaises(ValueError) as cx:
+                writer.writerow({"f4": 10, "f2": "spam", 1: "abc"})
+            exception = str(cx.exception)
+            self.assertIn("fieldnames", exception)
+            self.assertIn("'f4'", exception)
+            self.assertNotIn("'f2'", exception)
+            self.assertIn("1", exception)
+
+    def test_typo_in_extrasaction_raises_error(self):
+        fp = io.StringIO()
+        self.assertRaises(
+            ValueError,
+            clevercsv.DictWriter,
+            fp,
+            ["f1", "f2"],
+            extrasaction="raised",
+        )
+
+    def test_write_field_not_in_field_names_raise(self):
+        fp = io.StringIO()
+        writer = clevercsv.DictWriter(fp, ["f1", "f2"], extrasaction="raise")
+        dictrow = {"f0": 0, "f1": 1, "f2": 2, "f3": 3}
+        self.assertRaises(
+            ValueError, clevercsv.DictWriter.writerow, writer, dictrow
+        )
+
+    def test_write_field_not_in_field_names_ignore(self):
+        fp = io.StringIO()
+        writer = clevercsv.DictWriter(fp, ["f1", "f2"], extrasaction="ignore")
+        dictrow = {"f0": 0, "f1": 1, "f2": 2, "f3": 3}
+        clevercsv.DictWriter.writerow(writer, dictrow)
+        self.assertEqual(fp.getvalue(), "1,2\r\n")
+
+    def test_read_dict_fields(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("1,2,abc\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(fp, fieldnames=["f1", "f2", "f3"])
+            self.assertEqual(next(reader), {"f1": "1", "f2": "2", "f3": "abc"})
+
+    def test_read_dict_no_fieldnames(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("f1,f2,f3\r\n1,2,abc\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(fp)
+            self.assertEqual(next(reader), {"f1": "1", "f2": "2", "f3": "abc"})
+            self.assertEqual(reader.fieldnames, ["f1", "f2", "f3"])
+
+    # Two test cases to make sure existing ways of implicitly setting
+    # fieldnames continue to work.  Both arise from discussion in issue3436.
+    def test_read_dict_fieldnames_from_file(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("f1,f2,f3\r\n1,2,abc\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(
+                fp, fieldnames=next(clevercsv.reader(fp))
+            )
+            self.assertEqual(reader.fieldnames, ["f1", "f2", "f3"])
+            self.assertEqual(next(reader), {"f1": "1", "f2": "2", "f3": "abc"})
+
+    def test_read_dict_fieldnames_chain(self):
+        import itertools
+
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("f1,f2,f3\r\n1,2,abc\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(fp)
+            first = next(reader)
+            for row in itertools.chain([first], reader):
+                self.assertEqual(reader.fieldnames, ["f1", "f2", "f3"])
+                self.assertEqual(row, {"f1": "1", "f2": "2", "f3": "abc"})
+
+    def test_read_long(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("1,2,abc,4,5,6\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(fp, fieldnames=["f1", "f2"])
+            self.assertEqual(
+                next(reader),
+                {"f1": "1", "f2": "2", None: ["abc", "4", "5", "6"]},
+            )
+
+    def test_read_long_with_rest(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("1,2,abc,4,5,6\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(
+                fp, fieldnames=["f1", "f2"], restkey="_rest"
+            )
+            self.assertEqual(
+                next(reader),
+                {"f1": "1", "f2": "2", "_rest": ["abc", "4", "5", "6"]},
+            )
+
+    def test_read_long_with_rest_no_fieldnames(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("f1,f2\r\n1,2,abc,4,5,6\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(fp, restkey="_rest")
+            self.assertEqual(reader.fieldnames, ["f1", "f2"])
+            self.assertEqual(
+                next(reader),
+                {"f1": "1", "f2": "2", "_rest": ["abc", "4", "5", "6"]},
+            )
+
+    def test_read_short(self):
+        with tempfile.TemporaryFile("w+") as fp:
+            fp.write("1,2,abc,4,5,6\r\n1,2,abc\r\n")
+            fp.seek(0)
+            reader = clevercsv.DictReader(
+                fp, fieldnames="1 2 3 4 5 6".split(), restval="DEFAULT"
+            )
+            self.assertEqual(
+                next(reader),
+                {"1": "1", "2": "2", "3": "abc", "4": "4", "5": "5", "6": "6"},
+            )
+            self.assertEqual(
+                next(reader),
+                {
+                    "1": "1",
+                    "2": "2",
+                    "3": "abc",
+                    "4": "DEFAULT",
+                    "5": "DEFAULT",
+                    "6": "DEFAULT",
+                },
+            )
+
+    def test_read_multi(self):
+        sample = [
+            "2147483648,43.0e12,17,abc,def\r\n",
+            "147483648,43.0e2,17,abc,def\r\n",
+            "47483648,43.0,170,abc,def\r\n",
+        ]
+
+        reader = clevercsv.DictReader(
+            sample, fieldnames="i1 float i2 s1 s2".split()
+        )
+        self.assertEqual(
+            next(reader),
+            {
+                "i1": "2147483648",
+                "float": "43.0e12",
+                "i2": "17",
+                "s1": "abc",
+                "s2": "def",
+            },
+        )
+
+    def test_read_with_blanks(self):
+        reader = clevercsv.DictReader(
+            ["1,2,abc,4,5,6\r\n", "\r\n", "1,2,abc,4,5,6\r\n"],
+            fieldnames="1 2 3 4 5 6".split(),
+        )
+        self.assertEqual(
+            next(reader),
+            {"1": "1", "2": "2", "3": "abc", "4": "4", "5": "5", "6": "6"},
+        )
+        self.assertEqual(
+            next(reader),
+            {"1": "1", "2": "2", "3": "abc", "4": "4", "5": "5", "6": "6"},
+        )
+
+    def test_read_semi_sep(self):
+        reader = clevercsv.DictReader(
+            ["1;2;abc;4;5;6\r\n"],
+            fieldnames="1 2 3 4 5 6".split(),
+            delimiter=";",
+        )
+        self.assertEqual(
+            next(reader),
+            {"1": "1", "2": "2", "3": "abc", "4": "4", "5": "5", "6": "6"},
+        )
+
+    # End tests from CPython #
+    ##########################
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unit/test_dict.py
+++ b/tests/test_unit/test_dict.py
@@ -234,6 +234,16 @@ class DictTestCase(unittest.TestCase):
     # End tests from CPython #
     ##########################
 
+    ###################################
+    # Start tests added for CleverCSV #
+
+    def test_read_duplicate_fieldnames(self):
+        reader = clevercsv.DictReader(["f1,f2,f1\r\n", "a", "b", "c"])
+        with self.assertWarns(UserWarning):
+            reader.fieldnames
+
+    # End tests added for CleverCSV #
+    #################################
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When field names (headers) are not unique in a CSV file, the ``csv`` module's [DictReader](https://docs.python.org/3/library/csv.html#csv.DictReader) simply overwrites part of the data, as this is what happens with a ``dict`` as well: ``{'a': 1, 'b': 2, 'a': 3} = {'a': 3, 'b': 2}``. This is a [known issue](https://bugs.python.org/issue17537) in Python, but there is no consensus on how it should be handled.

In practice this can lead to unexpected data loss. With this PR we print a warning when this occurs, so the user is at least aware of the issue. Warnings can be easily suppressed (see [warning module](https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings)), so I don't expect this to be a significant burden on the end user. Hopefully this makes the DictReader less surprising.