### PR TITLE
Add encoding argument to write_table

### DIFF
--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -403,7 +403,9 @@ def detect_dialect(
     return dialect
 
 
-def write_table(table, filename, dialect="excel", transpose=False):
+def write_table(
+    table, filename, dialect="excel", transpose=False, encoding=None
+):
     """Write a table (a list of lists) to a file
 
     This is a convenience function for writing a table to a CSV file.
@@ -423,6 +425,12 @@ def write_table(table, filename, dialect="excel", transpose=False):
     transpose : bool
         Transpose the table before writing.
 
+    encoding : str
+        Encoding to use to write the data to the file. Note that the default
+        encoding is platform dependent, which ensures compatibility with the
+        Python open() function. It thus defaults to 
+        `locale.getpreferredencoding()`.
+
     Raises
     ------
     ValueError:
@@ -436,6 +444,6 @@ def write_table(table, filename, dialect="excel", transpose=False):
     if len(set(map(len, table))) > 1:
         raise ValueError("Table doesn't have constant row length.")
 
-    with open(filename, "w", newline="") as fp:
+    with open(filename, "w", newline="", encoding=encoding) as fp:
         w = writer(fp, dialect=dialect)
         w.writerows(table)

--- a/tests/test_unit/test_wrappers.py
+++ b/tests/test_unit/test_wrappers.py
@@ -228,7 +228,5 @@ class WrappersTestCase(unittest.TestCase):
             # locale.getpreferredencoding() (see gh-27).
             self._write_test(table, exp, encoding="utf-8")
 
-        table = [["Å", "B", "C"], [1, 2, 3], [4, 5, 6]]
-        exp = "Å,B,C\r\n1,2,3\r\n4,5,6\r\n"
         with self.subTest(name="encoding_2"):
             self._write_test(table, exp, encoding="cp1252")


### PR DESCRIPTION
This adds an optional `encoding` keyword argument to the `write_table` method, as suggested by @mitchgrogg. It fixes issue #27.