### PR TITLE
Add instructions on using pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,15 +341,10 @@ repository:
 
 ```yaml
 repos:
-  - repo: local
+  - repo: https://github.com/alan-turing-institute/CleverCSV-pre-commit
+    rev: v0.6.6   # or any later version
     hooks:
       - id: clevercsv-standardize
-        name: CleverCSV Standardize
-        entry: clevercsv standardize --in-place
-        language: python
-        language_version: python3
-        types: ["csv"]
-        additional_dependencies: ["clevercsv[full]"]
 ```
 
 Finally, run ``pre-commit install`` to set up the git hook. Pre-commit will 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ easier. We currently have the following helper functions:
   [stream_dicts](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.stream_dicts) 
   is also available.
 * [write_table](https://clevercsv.readthedocs.io/en/latest/source/clevercsv.html#clevercsv.wrappers.write_table): 
-  write a table (a list of lists) to a file using the RFC-4180 dialect.
+  write a table (a list of lists) to a file using the 
+  [RFC-4180](https://tools.ietf.org/html/rfc4180) dialect.
 
 Of course, you can also use the traditional way of loading a CSV file, as in 
 the Python CSV module:
@@ -309,7 +310,7 @@ CleverCSV has loaded the data into the variable: df
 #### Standardize
 
 Use the ``standardize`` command when you want to rewrite a file using the 
-RFC-4180 standard:
+[RFC-4180 standard](https://tools.ietf.org/html/rfc4180):
 
 ```text
 $ clevercsv standardize --output imdb_standard.csv imdb.csv

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import it.*
 
 ---
 
-*Contents:* <a href="#introduction"><b>Introduction</b></a> | <a href="#installation"><b>Installation</b></a> | <a href="#usage"><b>Usage</b></a> | <a href="#python-library">Python Library</a> | <a href="#command-line-tool">Command-Line Tool</a> | <a href="#contributing"><b>Contributing</b></a> | <a href="#notes"><b>Notes</b></a>
+*Contents:* <a href="#introduction"><b>Introduction</b></a> | <a href="#installation"><b>Installation</b></a> | <a href="#usage"><b>Usage</b></a> | <a href="#python-library">Python Library</a> | <a href="#command-line-tool">Command-Line Tool</a> | <a href="#version-control-integration">Version Control Integration</a> | <a href="#contributing"><b>Contributing</b></a> | <a href="#notes"><b>Notes</b></a>
 
 ---
 
@@ -328,6 +328,33 @@ before viewing or saving:
 ```text
 $ clevercsv view --transpose imdb.csv
 ```
+
+### Version Control Integration
+
+If you'd like to make sure that you never commit a messy (non-standard) CSV 
+file to your repository, you can install a 
+[pre-commit](https://pre-commit.com/) hook. First, install pre-commit using 
+the [installation instructions](https://pre-commit.com/#install). Next, add 
+the following configuration to the ``.pre-commit-config.yaml`` file in your 
+repository:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: clevercsv-standardize
+        name: CleverCSV Standardize
+        entry: clevercsv standardize --in-place
+        language: python
+        language_version: python3
+        types: ["csv"]
+        additional_dependencies: ["clevercsv[full]"]
+```
+
+Finally, run ``pre-commit install`` to set up the git hook. Pre-commit will 
+now use CleverCSV to standardize your CSV files following 
+[RFC-4180](https://tools.ietf.org/html/rfc4180) whenever you commit a CSV file 
+to your repository.
 
 ## Contributing
 


### PR DESCRIPTION
I believe this PR fixes #24.

@lcnittl I made an attempt at adding the pre-commit hook myself (hope you don't mind). It turned out that registering the hook with the repo link will always require pre-commit to install CleverCSV from the repo, which requires compilation (as you discovered as well). ~~By using ``repo: local`` and specifying CleverCSV as a dependency, we ensure that the pre-compiled wheel will be installed from PyPI.~~

Update for posterity: the solution we went with is to use a [dummy package](https://github.com/alan-turing-institute/clevercsv-pre-commit) that depends on ``clevercsv[full]``, which contains the pre-commit hook. This PR has been updated with the new instructions.