### PR TITLE
Add support for non-native architectures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,17 +7,11 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for ${{ matrix.arch }}
+    name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'windows-2019', 'macos-10.15' ]
-        arch: [auto, aarch64]
-        exclude:
-          - os: macos-10.15
-            arch: aarch64
-          - os: windows-2019
-            arch: aarch64
 
     steps:
       - uses: actions/checkout@v2
@@ -28,21 +22,18 @@ jobs:
           python-version: '3.7'
 
       - name: Set up QEMU
-        if: ${{ matrix.arch == 'aarch64' }}
+        if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
-
-      - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir ./wheelhouse
+      - uses: pypa/cibuildwheel@v1.12.0
         env:
-          CIBW_ARCHS_LINUX: ${{matrix.arch}}
           CIBW_TEST_COMMAND: "python -VV && python -m unittest discover -f -s {project}/tests/test_unit/"
           CIBW_TEST_EXTRAS: "full"
           CIBW_SKIP: "pp* cp27-* cp33-* cp34-* cp35-*"
+          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_ARCHS_LINUX: auto aarch64
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This builds on PR #40 by @odidev, and adds support for building wheels for non-native architectures on MacOS as well. Closes #39 