### PR TITLE
Add man pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ author = "G.J.J. van den Burg"
 # -- General configuration ---------------------------------------------------
 
 master_doc = 'index'
+smartquotes_action = "qe"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -56,3 +57,57 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# -- Options for manual page output ------------------------------------------
+
+_man_authors = ["Louis-Philippe Véronneau", author]
+
+# Man pages, they are writter to be generated directly by `rst2man` so using
+# Sphinx to build them will give weird sections, but if we ever need it it's
+# there
+
+# (source start file, name, description, authors, manual section).
+man_pages = [
+    (
+        "man/clevercsv",
+        "clevercsv",
+        "clevercsv command line interface",
+        _man_authors,
+        1,
+    ),
+    (
+        "man/clevercsv-code",
+        "clevercsv-code",
+        "clevercsv code commands",
+        _man_authors,
+        1,
+    ),
+    (
+        "man/clevercsv-detect",
+        "clevercsv-detect",
+        "clevercsv detect commands",
+        _man_authors,
+        1,
+    ),
+    (
+        "man/clevercsv-explore",
+        "clevercsv-explore",
+        "clevercsv explore commands",
+        _man_authors,
+        1,
+    ),
+    (
+        "man/clevercsv-standardize",
+        "clevercsv-standardize",
+        "clevercsv standardize commands",
+        _man_authors,
+        1,
+    ),
+    (
+        "man/clevercsv-view",
+        "clevercsv-view",
+        "clevercsv view commands",
+        _man_authors,
+        1,
+    ),
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@
 
    _changelog
    source/modules
+   man/index
 
 
 Indices and tables

--- a/docs/man/clevercsv-code.rst
+++ b/docs/man/clevercsv-code.rst
@@ -1,0 +1,51 @@
+clevercsv-code
+==============
+
+SYNOPSIS
+--------
+
+clevercsv code **--help**
+
+clevercsv code [**-e** <*encoding>*] [**-i**] [**-n** <*num_char*>] [**-p**] <*path*>
+
+DESCRIPTION
+-----------
+
+The code subcommand generates Python code for importing the specified CSV file.
+This is especially useful if you don't want to repeatedly detect the dialect of
+the same file.
+
+OPTIONS
+-------
+
+**-h**, **--help**
+    Shows help and exits. Depending on where this option appears it will either
+    list the available commands or display help for a specific command.
+
+**-e**, **--encoding** <*encoding*>
+    Set the encoding of the CSV file.
+
+**--i**, **--interact**
+    Drop into a Python interactive shell.
+
+**-n**, **--num-chars** <*num_chars*>
+    Limit the number of characters to read for detection. This will speed up
+    detection but may reduce accuracy.
+
+**-p**, **--pandas**
+   Write code that imports to a Pandas DataFrame.
+
+EXAMPLES
+--------
+
+You can generate the Python code by running::
+
+    $ clevercsv code yourfile.csv
+
+Copy the generated code to a Python script and you're good to go!
+
+SEE ALSO
+--------
+
+``clevercsv (1)``, ``clevercsv-detect (1)``, ``clevercsv-explore (1)``,
+``clevercsv-standardize (1)``, ``clevercsv-view (1)``

--- a/docs/man/clevercsv-detect.rst
+++ b/docs/man/clevercsv-detect.rst
@@ -1,0 +1,46 @@
+clevercsv-detect
+==============
+
+SYNOPSIS
+--------
+
+clevercsv detect **--help**
+
+clevercsv detect [**-c**] [**-e** <*encoding>*] [**-n** <*num_char*>] [**-p**] [**-j**] [**--no-skip**] <*path*>
+
+DESCRIPTION
+-----------
+
+The detect subcommand detects the dialect of a given CSV file.
+
+OPTIONS
+-------
+
+**-h**, **--help**
+    Shows help and exits. Depending on where this option appears it will either
+    list the available commands or display help for a specific command.
+
+**-c**, **--consitency**
+    Use only the consistency measure for detection.
+
+**-e**, **--encoding** <*encoding*>
+    Set the encoding of the CSV file.
+
+**-n**, **--num-chars** <*num_chars*>
+    Limit the number of characters to read for detection. This will speed up
+    detection but may reduce accuracy.
+
+**-p**, **--plain**
+    Print the components of the dialect on separate lines.
+
+**-j**, **--json**
+    Print the components of the dialect as a JSON object.
+
+**--no-skip**
+    Don't skip type detection for dialects with low pattern score.
+
+SEE ALSO
+--------
+
+``clevercsv (1)``, ``clevercsv-code (1)``, ``clevercsv-explore (1)``,
+``clevercsv-standardize (1)``, ``clevercsv-view (1)``

--- a/docs/man/clevercsv-explore.rst
+++ b/docs/man/clevercsv-explore.rst
@@ -1,0 +1,51 @@
+clevercsv-explore
+==============
+
+SYNOPSIS
+--------
+
+clevercsv explore **--help**
+
+clevercsv explore [**-e** <*encoding>*] [**-n** <*num_char*>] [**-p**] <*path*>
+
+DESCRIPTION
+-----------
+
+The explore subcommand allows you to quickly explore a CSV file in an
+interactive Python shell. This command detects the dialect of the CSV file and
+drops you into a Python interactive shell (REPL), with the CSV file already
+loaded.
+
+OPTIONS
+-------
+
+**-h**, **--help**
+    Shows help and exits. Depending on where this option appears it will either
+    list the available commands or display help for a specific command.
+
+**-e**, **--encoding** <*encoding*>
+    Set the encoding of the CSV file.
+
+**-n**, **--num-chars** <*num_chars*>
+    Limit the number of characters to read for detection. This will speed up
+    detection but may reduce accuracy.
+
+**-p**, **--pandas**
+   Read code into a Pandas dataframe.
+
+EXAMPLES
+--------
+
+To start working with the file loaded as a list of lists, run::
+
+    $ clevercsv explore yourfile.csv
+
+Alternatively, you can read the file as a Pandas dataframe by running::
+
+    $ clevercsv explore -p yourfile.csv
+
+SEE ALSO
+--------
+
+``clevercsv (1)``, ``clevercsv-code (1)``, ``clevercsv-detect (1)``,
+``clevercsv-standardize (1)``, ``clevercsv-view (1)``

--- a/docs/man/clevercsv-standardize.rst
+++ b/docs/man/clevercsv-standardize.rst
@@ -1,0 +1,54 @@
+clevercsv-standardize
+=====================
+
+SYNOPSIS
+--------
+
+clevercsv standardize **--help**
+
+clevercsv standardize [**-e** <*encoding>*] [**-i**] [**-n** <*num_char*>] [**-o** <*output*>] [**-t**] <*path1*> ... [*<pathN*>]
+
+DESCRIPTION
+-----------
+
+The standardize subcommand can be used to convert a non-standard CSV file to
+the standard RFC-4180 format [1].
+
+When using the **--in-place** option, the return code of CleverCSV can be used
+to check whether a file was altered or not. The return code will be 2 when the
+file was altered and 0 otherwise.
+
+[1]: https://tools.ietf.org/html/rfc4180
+
+OPTIONS
+-------
+
+**-h**, **--help**
+    Shows help and exits. Depending on where this option appears it will either
+    list the available commands or display help for a specific command.
+
+**-e**, **--encoding** <*encoding*>
+      Set the encoding of the CSV file. This will also be used for the output
+      file. When multiple input files are provided but only a single encoding
+      is given, the encoding will be used for all files. If the encoding is not
+      provided it will be detected. (multiple values allowed)
+
+**--i**, **--in-place**
+    Standardize and overwrite the input file(s).
+
+**-n**, **--num-chars** <*num_chars*>
+    Limit the number of characters to read for detection. This will speed up
+    detection but may reduce accuracy.
+
+**-o**, **--output**
+    Output file to write to. If omitted, print to stdout. (multiple values
+    allowed)
+
+**-t**, **--transpose**
+    Transpose the columns of the file before writing.
+
+SEE ALSO
+--------
+
+``clevercsv (1)``, ``clevercsv-code (1)``, ``clevercsv-detect (1)``,
+``clevercsv-explore (1)``, ``clevercsv-view (1)``

--- a/docs/man/clevercsv-view.rst
+++ b/docs/man/clevercsv-view.rst
@@ -1,0 +1,38 @@
+clevercsv-view
+==============
+
+SYNOPSIS
+--------
+
+clevercsv view **--help**
+
+clevercsv view [**-e** <*encoding>*][**-n** <*num_char*>] [**-t**] <*path*>
+
+DESCRIPTION
+-----------
+
+The view subcommand allows to view a CSV file on the command line, using
+TabView.
+
+OPTIONS
+-------
+
+**-h**, **--help**
+    Shows help and exits. Depending on where this option appears it will either
+    list the available commands or display help for a specific command.
+
+**-e**, **--encoding** <*encoding*>
+    Set the encoding of the CSV file.
+
+**-n**, **--num-chars** <*num_chars*>
+    Limit the number of characters to read for detection. This will speed up
+    detection but may reduce accuracy.
+
+**-t**, **--transpose**
+   Transpose the columns of the file before viewing.
+
+SEE ALSO
+--------
+
+``clevercsv (1)``, ``clevercsv-code (1)``, ``clevercsv-detect (1)``,
+``clevercsv-explore (1)``, ``clevercsv-standardize (1)``

--- a/docs/man/clevercsv.rst
+++ b/docs/man/clevercsv.rst
@@ -1,0 +1,65 @@
+clevercsv
+=========
+
+SYNOPSIS
+--------
+
+clevercsv *--help*
+
+clevercsv *--version*
+
+clevercsv [*--verbose*] **command** [*options*]
+
+DESCRIPTION
+-----------
+
+Handy command line tool that can standardize messy CSV files or generate Python
+code to import them.
+
+SUBCOMMANDS
+-----------
+
+clevercsv has five different subcommands:
+
+**code** [*options*]
+    Generate Python code for importing the CSV file
+
+**detect** [*options*]
+   Detect the dialect of a CSV file
+
+**explore** [*options*]
+   Drop into a Python shell with the CSV file loaded
+
+**standardize** [*options*]
+   Convert a CSV file to one that conforms to RFC-4180
+
+**view** [*options*]
+   View the CSV file on the command line using TabView
+
+For more details on the subcommands, see their respective man pages.
+
+OPTIONS
+-------
+
+**-h**, **--help**
+    Shows the help and exits. At top level it only lists the subcommands. To
+    display the help of a specific subcommand, add the **--help** flag *after*
+    said subcommand name.
+
+**-v**, **--verbose**
+    Enable verbose mode.
+
+**-V**, **--version**
+    Display the version number.
+
+BUGS
+----
+
+Bugs can be reported to your distribution's bug tracker or upstream
+at https://github.com/alan-turing-institute/CleverCSV/issues
+
+SEE ALSO
+--------
+
+``clevercsv-code (1)``, ``clevercsv-detect (1)``, ``clevercsv-explore (1)``,
+``clevercsv-standardize (1)``, ``clevercsv-view (1)``

--- a/docs/man/index.rst
+++ b/docs/man/index.rst
@@ -1,0 +1,14 @@
+Man pages
+=========
+
+.. rubric:: Command-line interface
+
+.. toctree::
+   :maxdepth: 1
+
+   clevercsv
+   clevercsv-code
+   clevercsv-detect
+   clevercsv-explore
+   clevercsv-standardize
+   clevercsv-view


### PR DESCRIPTION
Here are some man pages, tweaked from the help output. They should build for the HTML and the man output and look similar with both outputs.

Once generated with sphinx, you can view them using:

    man ./clevercsv.1