### PR TITLE
setup.py: Import distutils directly instead of through setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup
-from setuptools._distutils.core import Command
+from setuptools import Command
 
 # Package meta-data.
 AUTHOR = "Gertjan van den Burg"


### PR DESCRIPTION
In setuptools 65.6.0 the vendored distutils package changed to relative
imports. Importing `Command` from `setuptools._distutils` previously
worked but now fails because it imports an unpatched version of
distutils, which breaks the build.

Importing `Command` directly from `distutils` or `setuputils` will
receive a monkey patched version that works.

Reported upstream at https://github.com/pypa/setuptools/issues/3743 and the problem was investigated by Anderson Bravalheri.

Closes: #77