### PR TITLE
Migrate cchardet to faust-cchardet

### DIFF
--- a/clevercsv/_optional.py
+++ b/clevercsv/_optional.py
@@ -18,7 +18,7 @@ import importlib
 VERSIONS = {
     "tabview": "1.4",
     "pandas": "0.24.1",
-    "cchardet": "2.1.7",
+    "faust-cchardet": "2.1.14",
     "wilderness": "0.1.5",
 }
 

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ REQUIRED = [
 
 # When these are changed, update clevercsv/_optional.py accordingly
 full_require = [
+    "faust-cchardet>=2.1.14",
     "pandas>=1.0.0",
     "tabview>=1.4",
-    "cchardet>=2.1.7",
     "wilderness>=0.1.5",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import glob
 import io
 import os
 
+from setuptools import Command
 from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup
-from setuptools import Command
 
 # Package meta-data.
 AUTHOR = "Gertjan van den Burg"
@@ -29,7 +29,8 @@ REQUIRED = [
 
 # When these are changed, update clevercsv/_optional.py accordingly
 full_require = [
-    "faust-cchardet>=2.1.14",
+    "cchardet>=2.1.7; python_version<'3.11'",
+    "faust-cchardet>=2.1.14; platform_system!='Windows'",
     "pandas>=1.0.0",
     "tabview>=1.4",
     "wilderness>=0.1.5",

--- a/tests/test_unit/test_encoding.py
+++ b/tests/test_unit/test_encoding.py
@@ -10,6 +10,7 @@ This file is part of CleverCSV.
 """
 
 import os
+import platform
 import tempfile
 import unittest
 
@@ -18,6 +19,25 @@ from clevercsv.write import writer
 
 
 class EncodingTestCase(unittest.TestCase):
+
+    cases = [
+        {
+            "table": [["Å", "B", "C"], [1, 2, 3], [4, 5, 6]],
+            "encoding": "ISO-8859-1",
+            "cchardet_encoding": "WINDOWS-1252",
+        },
+        {
+            "table": [["A", "B", "C"], [1, 2, 3], [4, 5, 6]],
+            "encoding": "ascii",
+            "cchardet_encoding": "ASCII",
+        },
+        {
+            "table": [["亜唖", "娃阿", "哀愛"], [1, 2, 3], ["挨", "姶", "葵"]],
+            "encoding": "ISO-2022-JP",
+            "cchardet_encoding": "ISO-2022-JP",
+        },
+    ]
+
     def setUp(self):
         self._tmpfiles = []
 
@@ -37,44 +57,30 @@ class EncodingTestCase(unittest.TestCase):
         self._tmpfiles.append(tmpfname)
         return tmpfname
 
-    def test_encoding_1(self):
-        table = [["Å", "B", "C"], [1, 2, 3], [4, 5, 6]]
-        encoding = "ISO-8859-1"
-        tmpfname = self._build_file(table, encoding)
+    def test_encoding_chardet(self):
+        for case in self.cases:
+            table = case["table"]
+            encoding = case["encoding"]
+            with self.subTest(encoding=encoding):
+                tmpfname = self._build_file(table, encoding)
+                detected = get_encoding(tmpfname, try_cchardet=False)
+                self.assertEqual(encoding, detected)
 
-        # Test using chardet
-        detected = get_encoding(tmpfname, try_cchardet=False)
-        self.assertEqual(encoding, detected)
-
-        # Test using cChardet
-        detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual("WINDOWS-1252", detected)
-
-    def test_encoding_2(self):
-        table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
-        encoding = "ascii"
-        tmpfname = self._build_file(table, encoding)
-
-        # Test using chardet
-        detected = get_encoding(tmpfname, try_cchardet=False)
-        self.assertEqual(encoding, detected)
-
-        # Test using cChardet
-        detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual("ASCII", detected)
-
-    def test_encoding_3(self):
-        table = [["亜唖", "娃阿", "哀愛"], [1, 2, 3], ["挨", "姶", "葵"]]
-        encoding = "ISO-2022-JP"
-        tmpfname = self._build_file(table, encoding)
-
-        # Test using chardet
-        detected = get_encoding(tmpfname)
-        self.assertEqual(encoding, detected)
-
-        # Test using cChardet
-        detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual(encoding, detected)
+    # Temporarily, until https://github.com/faust-streaming/cChardet/pull/15 is
+    # resolved.
+    @unittest.skipIf(
+        platform.system() == "Windows",
+        reason="No faust-cchardet wheels for Windows (yet)",
+    )
+    def test_encoding_cchardet(self):
+        for case in self.cases:
+            table = case["table"]
+            encoding = case["encoding"]
+            with self.subTest(encoding=encoding):
+                out_encoding = case["cchardet_encoding"]
+                tmpfname = self._build_file(table, encoding)
+                detected = get_encoding(tmpfname, try_cchardet=True)
+                self.assertEqual(out_encoding, detected)
 
 
 if __name__ == "__main__":

--- a/tests/test_unit/test_encoding.py
+++ b/tests/test_unit/test_encoding.py
@@ -48,7 +48,7 @@ class EncodingTestCase(unittest.TestCase):
 
         # Test using cChardet
         detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual("WINDOWS-1252", detected)
+        self.assertEqual(encoding, detected)
 
     def test_encoding_2(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
@@ -61,7 +61,7 @@ class EncodingTestCase(unittest.TestCase):
 
         # Test using cChardet
         detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual("ASCII", detected)
+        self.assertEqual(encoding, detected)
 
     def test_encoding_3(self):
         table = [["亜唖", "娃阿", "哀愛"], [1, 2, 3], ["挨", "姶", "葵"]]

--- a/tests/test_unit/test_encoding.py
+++ b/tests/test_unit/test_encoding.py
@@ -48,7 +48,7 @@ class EncodingTestCase(unittest.TestCase):
 
         # Test using cChardet
         detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual(encoding, detected)
+        self.assertEqual("WINDOWS-1252", detected)
 
     def test_encoding_2(self):
         table = [["A", "B", "C"], [1, 2, 3], [4, 5, 6]]
@@ -61,7 +61,7 @@ class EncodingTestCase(unittest.TestCase):
 
         # Test using cChardet
         detected = get_encoding(tmpfname, try_cchardet=True)
-        self.assertEqual(encoding, detected)
+        self.assertEqual("ASCII", detected)
 
     def test_encoding_3(self):
         table = [["亜唖", "娃阿", "哀愛"], [1, 2, 3], ["挨", "姶", "葵"]]


### PR DESCRIPTION
This PR moves the optional dependency [cchardet](https://github.com/PyYoshi/cChardet) to the fork [faust-cchardet](https://github.com/faust-streaming/cChardet). Moving to chardet-normalizer was attempted, but this didn't pass the test cases without significant modification.