### PR TITLE
Simplify faust-cchardet import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ REQUIRED = [
 
 # When these are changed, update clevercsv/_optional.py accordingly
 full_require = [
-    "cchardet>=2.1.7; python_version<'3.11'",
-    "faust-cchardet>=2.1.14; platform_system!='Windows'",
+    "faust-cchardet>=2.1.18",
     "pandas>=1.0.0",
     "tabview>=1.4",
     "wilderness>=0.1.5",


### PR DESCRIPTION
This PR simplifies the use of the faust-cchardet dependency now that it's available as wheel on Windows