### PR TITLE
Add pre-commit lint for invalid escape sequences and fix remaining error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
       - id: isort
         name: isort (pyi)
         types: [pyi]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.261'
+    hooks:
+      - id: ruff
+        name: ruff (python)
+        args: [--fix, --exit-non-zero-on-fix]

--- a/clevercsv/normal_form.py
+++ b/clevercsv/normal_form.py
@@ -155,7 +155,7 @@ def every_row_has_delim(rows, dialect):
 
 def is_elementary(cell):
     return not (
-        regex.fullmatch("[a-zA-Z0-9\.\_\&\-\@\+\%\(\)\ \/]+", cell) is None
+        regex.fullmatch(r"[a-zA-Z0-9\.\_\&\-\@\+\%\(\)\ \/]+", cell) is None
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,7 @@ sections=["FUTURE", "STDLIB", "TYPING", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER
 known_typing=["typing"]
 force_single_line=true
 lines_between_types=1
+
+[tool.ruff]
+# Detect invalid escape sequences in string literals
+select = ["W605"]


### PR DESCRIPTION
Hello again! 👋

Thanks for merging my previous PR, #90. I was still missing an invalid escape sequence in `clevercsv.normal_form`, so I fixed that and added a pre-commit hook to detect invalid escape sequences in the future.
Sorry for the noise.
I used `ruff` to add the lint to your pre-commit configuration, but only enabled the rule for detecting invalid escape sequences as I didn't want to force you to adhere to the entirety of `ruff`s ruleset.
That would make this PR pretty noisy as well.

If you would like to only fix the invalid escape sequences, and not use `ruff` for detecting future ones, let me know and I will remove the `ruff` configuration from this PR.

### Commits

- Use ruff pre-commit to detect invalid escape sequences.
- Fix invalid escape sequence in `clevercsv.normal_form`.
