### PR TITLE
standardize : allow users to specify output encoding

### DIFF
--- a/clevercsv/console/commands/standardize.py
+++ b/clevercsv/console/commands/standardize.py
@@ -75,9 +75,9 @@ class StandardizeCommand(Command):
             help="Set the encoding of the output file(s)",
             description=(
                 "If ommited, the output file encoding while be the same "
-                "as that of the original file."            
+                "as that of the original file."
             ),
-            type=str
+            type=str,
         )
         self.add_argument(
             "-i",
@@ -165,7 +165,7 @@ class StandardizeCommand(Command):
                 encoding=encoding,
                 verbose=verbose,
                 num_chars=num_chars,
-                target_encoding=target_encoding
+                target_encoding=target_encoding,
             )
             if retval > 0 and global_retval == 0:
                 global_retval = retval
@@ -180,7 +180,7 @@ class StandardizeCommand(Command):
         encoding: Optional[str] = None,
         num_chars: Optional[int] = None,
         verbose: bool = False,
-        target_encoding: Optional[str] = None
+        target_encoding: Optional[str] = None,
     ) -> int:
         encoding = encoding or get_encoding(path)
         target_encoding = target_encoding or encoding
@@ -238,7 +238,11 @@ class StandardizeCommand(Command):
             self._write_direct(path, stream, dialect, encoding)
 
     def _in_place(
-        self, path: StrPath, dialect: SimpleDialect, encoding: Optional[str], target_encoding: Optional[str]
+        self,
+        path: StrPath,
+        dialect: SimpleDialect,
+        encoding: Optional[str],
+        target_encoding: Optional[str],
     ) -> int:
         """In-place mode overwrites the input file, if necessary
 
@@ -277,7 +281,7 @@ class StandardizeCommand(Command):
         output: StrPath,
         dialect: SimpleDialect,
         encoding: Optional[str],
-        target_encoding: Optional[str]
+        target_encoding: Optional[str],
     ) -> int:
         with open(output, "w", newline="", encoding=target_encoding) as fp:
             self._write_to_stream(path, fp, dialect, encoding)

--- a/clevercsv/console/commands/standardize.py
+++ b/clevercsv/console/commands/standardize.py
@@ -71,7 +71,7 @@ class StandardizeCommand(Command):
         )
         self.add_argument(
             "-E",
-            "--target_encoding",
+            "--target-encoding",
             help="Set the encoding of the output file(s)",
             description=(
                 "If ommited, the output file encoding while be the same "

--- a/clevercsv/console/commands/standardize.py
+++ b/clevercsv/console/commands/standardize.py
@@ -202,7 +202,7 @@ class StandardizeCommand(Command):
         path: StrPath,
         stream: SupportsWrite[str],
         dialect: SimpleDialect,
-        encoding: Optional[str]
+        encoding: Optional[str],
     ) -> None:
         with open(path, "r", newline="", encoding=encoding) as fp:
             read = reader(fp, dialect=dialect)
@@ -217,7 +217,7 @@ class StandardizeCommand(Command):
         path: StrPath,
         stream: SupportsWrite[str],
         dialect: SimpleDialect,
-        encoding: Optional[str]
+        encoding: Optional[str],
     ) -> None:
         with open(path, "r", newline="", encoding=encoding) as fp:
             read = reader(fp, dialect=dialect)
@@ -230,7 +230,7 @@ class StandardizeCommand(Command):
         path: StrPath,
         stream: SupportsWrite[str],
         dialect: SimpleDialect,
-        encoding: Optional[str]
+        encoding: Optional[str],
     ) -> None:
         if self.args.transpose:
             self._write_transposed(path, stream, dialect, encoding)

--- a/clevercsv/console/commands/standardize.py
+++ b/clevercsv/console/commands/standardize.py
@@ -70,8 +70,13 @@ class StandardizeCommand(Command):
             default=[],
         )
         self.add_argument(
-            "-c",
-            "--convert_encoding",
+            "-E",
+            "--target_encoding",
+            help="Set the encoding of the output file(s)",
+            description=(
+                "If ommited, the output file encoding while be the same "
+                "as that of the original file."            
+            ),
             type=str
         )
         self.add_argument(
@@ -120,7 +125,7 @@ class StandardizeCommand(Command):
         encodings = self.args.encoding
         num_chars = parse_int(self.args.num_chars, "num-chars")
         in_place = self.args.in_place
-        target_encoding = self.args.convert_encoding
+        target_encoding = self.args.target_encoding
 
         if in_place and outputs:
             print(

--- a/tests/test_unit/test_console.py
+++ b/tests/test_unit/test_console.py
@@ -643,9 +643,9 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
             any(map(os.unlink, tmpfnames))
 
     def test_standardize_target_encoding(self) -> None:
-        table: TableType = [["Å", "B", "C"], ['é', 'ü', '中'], [4, 5, 6]]
+        table: TableType = [["Å", "B", "C"], ["é", "ü", "中"], [4, 5, 6]]
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
-        encoding='utf-8'
+        encoding = "utf-8"
         tmpfname = self._build_file(table, dialect, encoding=encoding)
 
         tmpfd, tmpoutname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
@@ -653,7 +653,9 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
 
         application = build_application()
         tester = Tester(application)
-        tester.test_command("standardize", ["-o", tmpoutname, '-E', 'utf-8', tmpfname])
+        tester.test_command(
+            "standardize", ["-o", tmpoutname, "-E", "utf-8", tmpfname]
+        )
 
         # Excel format (i.e. RFC4180) *requires* CRLF
         crlf = "\r\n"
@@ -668,22 +670,27 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
             os.unlink(tmpoutname)
 
     def test_standardize_target_encoding2(self) -> None:
-        table: TableType = [["A", "B", "C"], ['é', 'è', 'à'], [4, 5, 6]]
+        table: TableType = [["A", "B", "C"], ["é", "è", "à"], [4, 5, 6]]
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
-        encoding='latin-1'
+        encoding = "latin-1"
         tmpfname = self._build_file(table, dialect, encoding=encoding)
-        self.assertEqual("ISO-8859-1", get_encoding(tmpfname, try_cchardet=False))
+        self.assertEqual(
+            "ISO-8859-1", get_encoding(tmpfname, try_cchardet=False)
+        )
         tmpfd, tmpoutname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
         os.close(tmpfd)
 
         application = build_application()
         tester = Tester(application)
-        tester.test_command("standardize", ["-o", tmpoutname, '-e', 'latin-1', '-E', 'utf-8', tmpfname])
+        tester.test_command(
+            "standardize",
+            ["-o", tmpoutname, "-e", "latin-1", "-E", "utf-8", tmpfname],
+        )
 
         # Excel format (i.e. RFC4180) *requires* CRLF
         crlf = "\r\n"
         exp = crlf.join(["A,B,C", "é,è,à", "4,5,6", ""])
-        
+
         self.assertEqual("utf-8", get_encoding(tmpoutname, try_cchardet=False))
         with open(tmpoutname, "r", newline="") as fp:
             output = fp.read()
@@ -694,13 +701,13 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
         finally:
             os.unlink(tmpfname)
             os.unlink(tmpoutname)
-            
 
-
-    def test_standardize_target_encoding_raise_UnicodeEncodeError(self) -> None:
-        table: TableType = [["Å", "B", "C"], ['é', 'ü', '中'], [4, 5, 6]]
+    def test_standardize_target_encoding_raise_UnicodeEncodeError(
+        self,
+    ) -> None:
+        table: TableType = [["Å", "B", "C"], ["é", "ü", "中"], [4, 5, 6]]
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
-        encoding='utf-8'
+        encoding = "utf-8"
         tmpfname = self._build_file(table, dialect, encoding=encoding)
 
         tmpfd, tmpoutname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
@@ -708,9 +715,12 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
 
         application = build_application()
         tester = Tester(application)
-        try :
+        try:
             with self.assertRaises(UnicodeEncodeError):
-                tester.test_command("standardize", ["-o", tmpoutname, '-E', 'latin-1', tmpfname])
+                tester.test_command(
+                    "standardize",
+                    ["-o", tmpoutname, "-E", "latin-1", tmpfname],
+                )
         finally:
             os.unlink(tmpfname)
             os.unlink(tmpoutname)

--- a/tests/test_unit/test_console.py
+++ b/tests/test_unit/test_console.py
@@ -660,7 +660,7 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
         # Excel format (i.e. RFC4180) *requires* CRLF
         crlf = "\r\n"
         exp = crlf.join(["Å,B,C", "é,ü,中", "4,5,6", ""])
-        with open(tmpoutname, "r", newline="") as fp:
+        with open(tmpoutname, "r", newline="", encoding="utf-8") as fp:
             output = fp.read()
 
         try:
@@ -692,7 +692,7 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
         exp = crlf.join(["A,B,C", "é,è,à", "4,5,6", ""])
 
         self.assertEqual("utf-8", get_encoding(tmpoutname, try_cchardet=False))
-        with open(tmpoutname, "r", newline="") as fp:
+        with open(tmpoutname, "r", newline="", encoding="utf-8") as fp:
             output = fp.read()
 
         try:

--- a/tests/test_unit/test_console.py
+++ b/tests/test_unit/test_console.py
@@ -21,6 +21,7 @@ from clevercsv import __version__
 from clevercsv._types import _DialectLike
 from clevercsv.console import build_application
 from clevercsv.dialect import SimpleDialect
+from clevercsv.encoding import get_encoding
 from clevercsv.write import writer
 
 TableType = List[List[Any]]
@@ -671,7 +672,7 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
         dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
         encoding='latin-1'
         tmpfname = self._build_file(table, dialect, encoding=encoding)
-
+        self.assertEqual("ISO-8859-1", get_encoding(tmpfname, try_cchardet=False))
         tmpfd, tmpoutname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
         os.close(tmpfd)
 
@@ -682,14 +683,19 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
         # Excel format (i.e. RFC4180) *requires* CRLF
         crlf = "\r\n"
         exp = crlf.join(["A,B,C", "é,è,à", "4,5,6", ""])
+        
+        self.assertEqual("utf-8", get_encoding(tmpoutname, try_cchardet=False))
         with open(tmpoutname, "r", newline="") as fp:
             output = fp.read()
 
         try:
             self.assertEqual(exp, output)
+
         finally:
             os.unlink(tmpfname)
             os.unlink(tmpoutname)
+            
+
 
     def test_standardize_target_encoding_raise_UnicodeEncodeError(self) -> None:
         table: TableType = [["Å", "B", "C"], ['é', 'ü', '中'], [4, 5, 6]]

--- a/tests/test_unit/test_console.py
+++ b/tests/test_unit/test_console.py
@@ -640,3 +640,28 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
                 self.assertEqual(contents, exp)
         finally:
             any(map(os.unlink, tmpfnames))
+
+    def test_standardize_target_encoding(self) -> None:
+        table: TableType = [["Å", "B", "C"], ['é', 'ü', '中'], [4, 5, 6]]
+        dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
+        encoding='utf-8'
+        tmpfname = self._build_file(table, dialect, encoding=encoding)
+
+        tmpfd, tmpoutname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
+        os.close(tmpfd)
+
+        application = build_application()
+        tester = Tester(application)
+        tester.test_command("standardize", ["-o", tmpoutname, '-E', 'utf-8', tmpfname])
+
+        # Excel format (i.e. RFC4180) *requires* CRLF
+        crlf = "\r\n"
+        exp = crlf.join(["Å,B,C", "é,ü,中", "4,5,6", ""])
+        with open(tmpoutname, "r", newline="") as fp:
+            output = fp.read()
+
+        try:
+            self.assertEqual(exp, output)
+        finally:
+            os.unlink(tmpfname)
+            os.unlink(tmpoutname)

--- a/tests/test_unit/test_console.py
+++ b/tests/test_unit/test_console.py
@@ -665,3 +665,21 @@ with open("{tmpfname}", "r", newline="", encoding="ASCII") as fp:
         finally:
             os.unlink(tmpfname)
             os.unlink(tmpoutname)
+
+    def test_standardize_target_encoding_raise_UnicodeEncodeError(self) -> None:
+        table: TableType = [["Å", "B", "C"], ['é', 'ü', '中'], [4, 5, 6]]
+        dialect = SimpleDialect(delimiter=";", quotechar="", escapechar="")
+        encoding='utf-8'
+        tmpfname = self._build_file(table, dialect, encoding=encoding)
+
+        tmpfd, tmpoutname = tempfile.mkstemp(prefix="ccsv_", suffix=".csv")
+        os.close(tmpfd)
+
+        application = build_application()
+        tester = Tester(application)
+        try :
+            with self.assertRaises(UnicodeEncodeError):
+                tester.test_command("standardize", ["-o", tmpoutname, '-E', 'latin-1', tmpfname])
+        finally:
+            os.unlink(tmpfname)
+            os.unlink(tmpoutname)


### PR DESCRIPTION
Add `-E --target-encoding` argument, so the user can specify an output encoding. 
If omitted, keep the original encoding.