### PR TITLE
Support loggers in verbose mode

### DIFF
--- a/clevercsv/normal_form.py
+++ b/clevercsv/normal_form.py
@@ -12,8 +12,11 @@ Author: Gertjan van den Burg
 
 """
 
+from __future__ import annotations
+
 import itertools
 
+from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Iterable
 from typing import List
@@ -24,7 +27,13 @@ import regex
 
 from .dialect import SimpleDialect
 from .escape import is_potential_escapechar
+from .utils import maybe_log_or_print
 from .utils import pairwise
+
+
+if TYPE_CHECKING:
+    import logging
+
 
 DELIMS: List[str] = [",", ";", "|", "\t"]
 QUOTECHARS: List[str] = ["'", '"']
@@ -35,6 +44,7 @@ def detect_dialect_normal(
     encoding: str = "UTF-8",
     delimiters: Optional[Iterable[str]] = None,
     verbose: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> Optional[SimpleDialect]:
     """Detect the normal form of a file from a given sample
 
@@ -57,8 +67,9 @@ def detect_dialect_normal(
     delimiters = list(delimiters)
     for delim, quotechar in itertools.product(delimiters, QUOTECHARS):
         if maybe_has_escapechar(data, encoding, delim, quotechar):
-            if verbose:
-                print("Not normal, has potential escapechar.")
+            maybe_log_or_print(
+                "Not normal, has potential escapechar.", verbose, logger
+            )
             return None
 
     form_and_dialect: List[
@@ -94,11 +105,11 @@ def detect_dialect_normal(
 
     for ID, form_func, dialect in form_and_dialect:
         if form_func(rows, dialect):
-            if verbose:
-                print("Matched normal form %i." % ID)
+            maybe_log_or_print(
+                "Matched normal form %i." % ID, verbose, logger
+            )
             return dialect
-    if verbose:
-        print("Didn't match any normal forms.")
+    maybe_log_or_print("Didn't match any normal forms.", verbose, logger)
     return None
 
 

--- a/clevercsv/normal_form.py
+++ b/clevercsv/normal_form.py
@@ -105,9 +105,7 @@ def detect_dialect_normal(
 
     for ID, form_func, dialect in form_and_dialect:
         if form_func(rows, dialect):
-            maybe_log_or_print(
-                "Matched normal form %i." % ID, verbose, logger
-            )
+            maybe_log_or_print("Matched normal form %i." % ID, verbose, logger)
             return dialect
     maybe_log_or_print("Didn't match any normal forms.", verbose, logger)
     return None

--- a/clevercsv/utils.py
+++ b/clevercsv/utils.py
@@ -7,16 +7,24 @@ Author: Gertjan van den Burg
 
 """
 
+from __future__ import annotations
+
 import hashlib
 
+from typing import TYPE_CHECKING
 from typing import Iterable
 from typing import Iterator
+from typing import Optional
 from typing import Tuple
 from typing import TypeVar
 
 from clevercsv._types import AnyPath
 
 T = TypeVar("T")
+
+
+if TYPE_CHECKING:
+    import logging
 
 
 def pairwise(iterable: Iterable[T]) -> Iterator[Tuple[T, T]]:
@@ -48,3 +56,24 @@ def sha1sum(filename: AnyPath) -> str:
             hasher.update(buf)
             buf = fp.read(blocksize)
     return hasher.hexdigest()
+
+
+def maybe_log_or_print(
+    msg: str, verbose: bool = False, logger: Optional[logging.Logger] = None
+) -> None:
+    """Log or print a message if verbose is True
+
+    Parameters
+    ----------
+    msg : str
+        The message to log or print.
+    verbose : bool
+        Whether to log or print a message.
+    logger : Optional[logging.Logger]
+        A logger instance.
+    """
+    if verbose:
+        if logger is not None:
+            logger.info(msg)
+        else:
+            print(msg)

--- a/clevercsv/wrappers.py
+++ b/clevercsv/wrappers.py
@@ -31,6 +31,8 @@ from .read import reader
 from .write import writer
 
 if TYPE_CHECKING:
+    import logging
+
     import pandas as pd
 
     from ._types import FileDescriptorOrPath
@@ -46,6 +48,7 @@ def stream_dicts(
     encoding: Optional[str] = None,
     num_chars: Optional[int] = None,
     verbose: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> Iterator["_DictReadMapping"]:
     """Read a CSV file as a generator over dictionaries
 
@@ -77,6 +80,10 @@ def stream_dicts(
     verbose: bool
         Whether or not to show detection progress.
 
+    logger : Optional[logging.Logger]
+        A logger object to log messages. Active only when verbose is True. If
+        None, messages are printed to stdout.
+
     Returns
     -------
     rows: generator
@@ -93,7 +100,7 @@ def stream_dicts(
     with open(filename, "r", newline="", encoding=encoding) as fid:
         if dialect is None:
             data = fid.read(num_chars) if num_chars else fid.read()
-            dialect = Detector().detect(data, verbose=verbose)
+            dialect = Detector().detect(data, verbose=verbose, logger=logger)
             fid.seek(0)
 
         if dialect is None:
@@ -110,6 +117,7 @@ def read_dicts(
     encoding: Optional[str] = None,
     num_chars: Optional[int] = None,
     verbose: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> List["_DictReadMapping"]:
     """Read a CSV file as a list of dictionaries
 
@@ -141,6 +149,10 @@ def read_dicts(
     verbose: bool
         Whether or not to show detection progress.
 
+    logger : Optional[logging.Logger]
+        A logger object to log messages. Active only when verbose is True. If
+        None, messages are printed to stdout.
+
     Returns
     -------
     rows: list
@@ -159,6 +171,7 @@ def read_dicts(
             encoding=encoding,
             num_chars=num_chars,
             verbose=verbose,
+            logger=logger,
         )
     )
 
@@ -169,6 +182,7 @@ def read_table(
     encoding: Optional[str] = None,
     num_chars: Optional[int] = None,
     verbose: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> List[List[str]]:
     """Read a CSV file as a table (a list of lists)
 
@@ -200,6 +214,10 @@ def read_table(
     verbose: bool
         Whether or not to show detection progress.
 
+    logger : Optional[logging.Logger]
+        A logger object to log messages. Active only when verbose is True. If
+        None, messages are printed to stdout.
+
     Returns
     -------
     rows: list
@@ -218,6 +236,7 @@ def read_table(
             encoding=encoding,
             num_chars=num_chars,
             verbose=verbose,
+            logger=logger,
         )
     )
 
@@ -228,6 +247,7 @@ def stream_table(
     encoding: Optional[str] = None,
     num_chars: Optional[int] = None,
     verbose: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> Iterator[List[str]]:
     """Read a CSV file as a generator over rows of a table
 
@@ -259,6 +279,10 @@ def stream_table(
     verbose: bool
         Whether or not to show detection progress.
 
+    logger : Optional[logging.Logger]
+        A logger object to log messages. Active only when verbose is True. If
+        None, messages are printed to stdout.
+
     Returns
     -------
     rows: generator
@@ -275,7 +299,7 @@ def stream_table(
     with open(filename, "r", newline="", encoding=encoding) as fid:
         if dialect is None:
             data = fid.read(num_chars) if num_chars else fid.read()
-            dialect = Detector().detect(data, verbose=verbose)
+            dialect = Detector().detect(data, verbose=verbose, logger=logger)
             if dialect is None:
                 raise NoDetectionResult()
             fid.seek(0)
@@ -354,6 +378,7 @@ def detect_dialect(
     verbose: bool = False,
     method: str = "auto",
     skip: bool = True,
+    logger: Optional[logging.Logger] = None,
 ) -> Optional[SimpleDialect]:
     """Detect the dialect of a CSV file
 
@@ -385,6 +410,10 @@ def detect_dialect(
         Skip computation of the type score for dialects with a low pattern
         score.
 
+    logger : Optional[logging.Logger]
+        A logger object to log messages. Active only when verbose is True. If
+        None, messages are printed to stdout.
+
     Returns
     -------
     dialect : Optional[SimpleDialect]
@@ -396,7 +425,7 @@ def detect_dialect(
     with open(filename, "r", newline="", encoding=enc) as fp:
         data = fp.read(num_chars) if num_chars else fp.read()
         dialect = Detector().detect(
-            data, verbose=verbose, method=method, skip=skip
+            data, verbose=verbose, method=method, skip=skip, logger=logger
         )
     return dialect
 


### PR DESCRIPTION
Thank you for this wonderful library!

A print statement is used for the various CleverCSV functions where one can set `verbose=True`, but a logger is sometimes preferred (if not necessary, especially in a production environment) for its flexibility in stream handling and other features unavailable to print statements. This pull request adds a `logger` keyword argument alongside the existing `verbose`, so that a `logging.Logger` instance can be passed in and used. No code changes are made under `clevercsv/console/`, as the logger doesn't appear to be relevant to the console use cases.
