### PR TITLE
Fix manpage issues

### DIFF
--- a/man/clevercsv-standardize.1
+++ b/man/clevercsv-standardize.1
@@ -60,7 +60,7 @@ The file encoding of the given CSV file is automatically detected using chardet.
 .PP
 \-E, \-\-target\-encoding
 .RS 4
-If ommited, the output file encoding while be the same as that of the original file.
+If omited, the output file encoding while be the same as that of the original file.
 .RE
 .PP
 \-i, \-\-in\-place

--- a/man/clevercsv.1
+++ b/man/clevercsv.1
@@ -106,4 +106,4 @@ If you encounter an issue in CleverCSV, please open an issue or submit a pull re
 .sp
 \fB3. \fRWrangling Messy CSV Files by Detecting Row and Type Patterns
 .br
-   https://gertjanvandenburg.com/papers/VandenBurg_Nazabal_Sutton_\-_Wrangling_Messy_CSV_Files_by_Detecting_Row_and_Type_Patterns_2019.pdf
+   https://gertjanvandenburg.com/papers/VandenBurg_Nazabal_Sutton_\:\&-_Wrangling_Messy_CSV_Files_by_Detecting_Row_and_Type_Patterns_2019.pdf


### PR DESCRIPTION
The Debian linting tool flagged 2 issues in the man page in the 0.8.3 release, here's a quick fix.

The `troff` warning can be reproduced with `LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z clevercsv.1 >/dev/null`