### PR TITLE
[README] Point to the active fork of cchardet in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ file, for example:
 dialect = clevercsv.Sniffer().sniff(fp.read(10000))
 ```
 You can also speed up encoding detection by installing 
-[cCharDet](https://github.com/PyYoshi/cChardet), it will automatically be used 
+[cCharDet](https://github.com/faust-streaming/cChardet/), it will automatically be used 
 when it is available on the system.
 
 That's the basics! If you want more details, you can look at the code of the 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -253,7 +253,7 @@ file, for example:
    dialect = clevercsv.Sniffer().sniff(fp.read(10000))
 
 You can also speed up encoding detection by installing 
-`cCharDet <https://github.com/PyYoshi/cChardet>`_\ , it will automatically be used 
+`cCharDet <https://github.com/faust-streaming/cChardet/>`_\ , it will automatically be used 
 when it is available on the system.
 
 That's the basics! If you want more details, you can look at the code of the 


### PR DESCRIPTION
We're pointing to the PyYoshi repo but the active up-to-date version is https://github.com/faust-streaming/cChardet/.

Updating docs to reflect that. (0.7.5 changed to that fork)