### PR TITLE
Fix AssertionError in DictReader.fieldnames on empty input

### DIFF
--- a/clevercsv/dict_read_write.py
+++ b/clevercsv/dict_read_write.py
@@ -65,7 +65,7 @@ class DictReader(
         return self
 
     @property
-    def fieldnames(self) -> Sequence[_T]:
+    def fieldnames(self) -> Optional[Sequence[_T]]:
         if self._fieldnames is None:
             try:
                 fieldnames = next(self.reader)
@@ -73,7 +73,8 @@ class DictReader(
             except StopIteration:
                 pass
 
-        assert self._fieldnames is not None
+        if self._fieldnames is None:
+            return None
 
         # Note: this was added because I don't think it's expected that Python
         # simply drops information if there are duplicate headers. There is

--- a/tests/test_unit/test_dict.py
+++ b/tests/test_unit/test_dict.py
@@ -252,6 +252,19 @@ class DictTestCase(unittest.TestCase):
         with self.assertWarns(UserWarning):
             reader.fieldnames
 
+    def test_read_empty_file_fieldnames_returns_none(self) -> None:
+        # Accessing .fieldnames on an empty file should return None (matching
+        # stdlib csv.DictReader behaviour), not raise AssertionError.
+        reader: DictReader[str] = clevercsv.DictReader(io.StringIO(""))
+        self.assertIsNone(reader.fieldnames)
+
+    def test_read_empty_file_iteration_raises_stopiteration(self) -> None:
+        # Iterating over an empty file should raise StopIteration, not
+        # AssertionError.
+        reader: DictReader[str] = clevercsv.DictReader(io.StringIO(""))
+        with self.assertRaises(StopIteration):
+            next(reader)
+
     # End tests added for CleverCSV #
     #################################
 


### PR DESCRIPTION
## Bug

`DictReader.fieldnames` raises an uncaught `AssertionError` when the
underlying reader produces no rows (e.g. an empty file or empty
string):

```python
import io
import clevercsv

r = clevercsv.DictReader(io.StringIO(""))
r.fieldnames  # AssertionError: assert self._fieldnames is not None
```

The same crash surfaces when iterating:

```python
next(clevercsv.DictReader(io.StringIO("")))  # AssertionError
```

The stdlib `csv.DictReader` returns `None` for `.fieldnames` on an
empty file and raises `StopIteration` on iteration — both are the
sensible, documented behaviours.

## Root cause

In `DictReader.fieldnames`, when `next(self.reader)` raises
`StopIteration` (empty input), `_fieldnames` stays `None`.  The line
immediately after the `try/except` block,

```python
assert self._fieldnames is not None
```

then fires unconditionally.

## Fix

Replace the assert with an explicit `if self._fieldnames is None: return None`
guard, matching stdlib behaviour.  The property return type annotation
is updated from `Sequence[_T]` to `Optional[Sequence[_T]]` accordingly.

## Tests

Two new test cases added to `tests/test_unit/test_dict.py`:
- `test_read_empty_file_fieldnames_returns_none` — asserts `fieldnames` returns `None`
- `test_read_empty_file_iteration_raises_stopiteration` — asserts iteration raises `StopIteration`

All 166 existing unit tests continue to pass.

---
This pull request was prepared with the assistance of AI, under my direction and review.