### PR TITLE
Explicitly define tool.setuptools.packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,10 +103,8 @@ packages = ["stubs", "clevercsv"]
 disallow_incomplete_defs = true
 
 [tool.setuptools]
+packages = ["clevercsv"]
 include-package-data = true
-
-[tool.setuptools.packages.find]
-exclude = ["tests*", "*.tests*"]
 
 [tool.setuptools.package-data]
 clevercsv = ["py.typed"]


### PR DESCRIPTION
Closes #172 .

I had to delete the `[tool.setuptools.packages.find]` line, otherwise build failed with:

```
pyproject.toml: TOMLDecodeError: Cannot declare ('tool', 'setuptools', 'packages', 'find') twice (at line 109, column 31)
W: pybuild plugin_pyproject:65: pyproject.toml: TOMLDecodeError: Cannot declare ('tool', 'setuptools', 'packages', 'find') twice (at line 109, column 31)
```

This doesn't seem to matter anyway, since the tests are outside of the `clevercsv` directory.

On my side this fixes the top_level.txt issue and I get this directory tree, which is exactly the same as the one I got for version 0.8.4:

```
/usr/bin/clevercsv
/usr/lib/python3/dist-packages/clevercsv-0.8.5.dist-info/
/usr/lib/python3/dist-packages/clevercsv-0.8.5.dist-info/INSTALLER
/usr/lib/python3/dist-packages/clevercsv-0.8.5.dist-info/METADATA
/usr/lib/python3/dist-packages/clevercsv-0.8.5.dist-info/entry_points.txt
/usr/lib/python3/dist-packages/clevercsv-0.8.5.dist-info/top_level.txt
/usr/lib/python3/dist-packages/clevercsv/__init__.py
/usr/lib/python3/dist-packages/clevercsv/__main__.py
/usr/lib/python3/dist-packages/clevercsv/__version__.py
/usr/lib/python3/dist-packages/clevercsv/_optional.py
/usr/lib/python3/dist-packages/clevercsv/_regexes.py
/usr/lib/python3/dist-packages/clevercsv/_types.py
/usr/lib/python3/dist-packages/clevercsv/break_ties.py
/usr/lib/python3/dist-packages/clevercsv/cabstraction.cpython-313-x86_64-linux-gnu.so
/usr/lib/python3/dist-packages/clevercsv/cabstraction.cpython-314-x86_64-linux-gnu.so
/usr/lib/python3/dist-packages/clevercsv/cabstraction.pyi
/usr/lib/python3/dist-packages/clevercsv/consistency.py
/usr/lib/python3/dist-packages/clevercsv/console/__init__.py
/usr/lib/python3/dist-packages/clevercsv/console/application.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/
/usr/lib/python3/dist-packages/clevercsv/console/commands/__init__.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/_docs.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/_utils.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/code.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/detect.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/explore.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/standardize.py
/usr/lib/python3/dist-packages/clevercsv/console/commands/view.py
/usr/lib/python3/dist-packages/clevercsv/cparser.cpython-313-x86_64-linux-gnu.so
/usr/lib/python3/dist-packages/clevercsv/cparser.cpython-314-x86_64-linux-gnu.so
/usr/lib/python3/dist-packages/clevercsv/cparser.pyi
/usr/lib/python3/dist-packages/clevercsv/cparser_util.py
/usr/lib/python3/dist-packages/clevercsv/cparser_util.pyi
/usr/lib/python3/dist-packages/clevercsv/detect.py
/usr/lib/python3/dist-packages/clevercsv/detect_pattern.py
/usr/lib/python3/dist-packages/clevercsv/detect_type.py
/usr/lib/python3/dist-packages/clevercsv/dialect.py
/usr/lib/python3/dist-packages/clevercsv/dict_read_write.py
/usr/lib/python3/dist-packages/clevercsv/encoding.py
/usr/lib/python3/dist-packages/clevercsv/escape.py
/usr/lib/python3/dist-packages/clevercsv/exceptions.py
/usr/lib/python3/dist-packages/clevercsv/normal_form.py
/usr/lib/python3/dist-packages/clevercsv/potential_dialects.py
/usr/lib/python3/dist-packages/clevercsv/py.typed
/usr/lib/python3/dist-packages/clevercsv/read.py
/usr/lib/python3/dist-packages/clevercsv/utils.py
/usr/lib/python3/dist-packages/clevercsv/wrappers.py
/usr/lib/python3/dist-packages/clevercsv/write.py
/usr/share/doc/python3-clevercsv/changelog.Debian.gz
/usr/share/doc/python3-clevercsv/changelog.gz
/usr/share/doc/python3-clevercsv/copyright
/usr/share/man/man1/clevercsv-code.1.gz
/usr/share/man/man1/clevercsv-detect.1.gz
/usr/share/man/man1/clevercsv-explore.1.gz
/usr/share/man/man1/clevercsv-help.1.gz
/usr/share/man/man1/clevercsv-standardize.1.gz
/usr/share/man/man1/clevercsv-view.1.gz
/usr/share/man/man1/clevercsv.1.gz
```